### PR TITLE
Add endpoint to completely purge a project's documents

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -42,6 +42,7 @@ app.del  '/project/:project_id/doc/:doc_id', HttpController.deleteDoc
 
 app.post  '/project/:project_id/archive', HttpController.archiveAllDocs
 app.post  '/project/:project_id/unarchive', HttpController.unArchiveAllDocs
+app.post  '/project/:project_id/destroy', HttpController.destroyAllDocs
 
 app.get "/health_check",  HttpController.healthCheck
 

--- a/app/coffee/HttpController.coffee
+++ b/app/coffee/HttpController.coffee
@@ -117,6 +117,13 @@ module.exports = HttpController =
 			return next(error) if error?
 			res.send 200
 
+	destroyAllDocs: (req, res, next = (error) ->) ->
+		project_id = req.params.project_id
+		logger.log project_id: project_id, "destroying all docs"
+		DocArchive.destroyAllDocs project_id, (error) ->
+			return next(error) if error?
+			res.send 204
+
 	healthCheck: (req, res)->
 		HealthChecker.check (err)->
 			if err?

--- a/app/coffee/MongoManager.coffee
+++ b/app/coffee/MongoManager.coffee
@@ -72,6 +72,14 @@ module.exports = MongoManager =
 			upsert: true
 		}, callback
 
+	destroyDoc: (doc_id, callback) ->
+		db.docs.remove {
+			_id: ObjectId(doc_id)
+		}, (err) ->
+			return callback(err) if err?
+			db.docOps.remove {
+				doc_id: ObjectId(doc_id)
+			}, callback
 
 [
 	'findDoc',

--- a/test/acceptance/coffee/helpers/DocstoreClient.coffee
+++ b/test/acceptance/coffee/helpers/DocstoreClient.coffee
@@ -44,8 +44,12 @@ module.exports = DocstoreClient =
 	archiveAllDoc: (project_id, callback = (error, res, body) ->) ->
 		request.post {
 			url: "http://localhost:#{settings.internal.docstore.port}/project/#{project_id}/archive"
-		}, callback	
+		}, callback
 
+	destroyAllDoc: (project_id, callback = (error, res, body) ->) ->
+		request.post {
+			url: "http://localhost:#{settings.internal.docstore.port}/project/#{project_id}/destroy"
+		}, callback
 
 	getS3Doc: (project_id, doc_id, callback = (error, res, body) ->) ->
 		options = DocArchiveManager.buildS3Options(project_id+"/"+doc_id)

--- a/test/unit/coffee/HttpControllerTests.coffee
+++ b/test/unit/coffee/HttpControllerTests.coffee
@@ -326,3 +326,17 @@ describe "HttpController", ->
 			@res.send
 				.calledWith(204)
 				.should.equal true
+
+	describe "destroyAllDocs", ->
+		beforeEach ->
+			@req.params =
+				project_id: @project_id
+			@DocArchiveManager.destroyAllDocs = sinon.stub().callsArg(1)
+			@HttpController.destroyAllDocs @req, @res, @next
+
+		it "should destroy the docs", ->
+			sinon.assert.calledWith(@DocArchiveManager.destroyAllDocs, @project_id)
+
+		it "should return 204", ->
+			sinon.assert.calledWith(@res.send, 204)
+

--- a/test/unit/coffee/MongoManagerTests.coffee
+++ b/test/unit/coffee/MongoManagerTests.coffee
@@ -110,6 +110,18 @@ describe "MongoManager", ->
 				err.should.equal @stubbedErr
 				done()
 
+	describe "destroyDoc", ->
+		beforeEach (done) ->
+			@db.docs.remove = sinon.stub().yields()
+			@db.docOps.remove = sinon.stub().yields()
+			@MongoManager.destroyDoc '123456789012', done
+
+		it "should destroy the doc", ->
+			sinon.assert.calledWith(@db.docs.remove, {_id: ObjectId('123456789012')})
+
+		it "should destroy the docOps", ->
+			sinon.assert.calledWith(@db.docOps.remove, {doc_id: ObjectId('123456789012')})
+
 	describe "getDocVersion", ->
 		describe "when the doc exists", ->
 			beforeEach ->


### PR DESCRIPTION
### Description

As part of the soft-deletion work, we need a way to hard-delete docs. We don't want to keep stuff around in S3 and Mongo forever.

This adds a new endpoint to delete a doc, both from Mongo and S3 (if it is archived.) - We plan to call this once a project has been deleted for 90 days.

#### Related Issues / PRs

Blocks overleaf/web-internal#1867

### Who needs to know?

cc @chrystalgriffiths 