### PR TITLE
Log request URL on error

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -50,7 +50,7 @@ app.get '/status', (req, res)->
 	res.send('docstore is alive')
 
 app.use (error, req, res, next) ->
-	logger.error err: error, "request errored"
+	logger.error err: error, req:req, "request errored"
 	if error instanceof Errors.NotFoundError
 		res.send 404
 	else


### PR DESCRIPTION
### Description

When an error is caught by the default error handler, add the request URL to the log message.

This allows us to search the docstore logs for an id and see these errors, which would otherwise not be shown.

#### Related Issues / PRs

Fixes overleaf/issues#2135