### PR TITLE
[misc] update the build scripts to 1.3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
-FROM node:10.19.0 as app
+# This file was auto-generated, do not edit it directly.
+# Instead run bin/update_build_scripts from
+# https://github.com/sharelatex/sharelatex-dev-environment
+# Version: 1.3.5
+
+FROM node:10.19.0 as base
 
 WORKDIR /app
+
+FROM base as app
 
 #wildcard as some files may not be in all repos
 COPY package*.json npm-shrink*.json /app/
@@ -12,11 +19,9 @@ COPY . /app
 
 RUN npm run compile:all
 
-FROM node:10.19.0
+FROM base
 
 COPY --from=app /app /app
-
-WORKDIR /app
 USER node
 
 CMD ["node", "--expose-gc", "app.js"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,7 @@ pipeline {
   }
 
   stages {
+
     stage('Install') {
       steps {
         withCredentials([usernamePassword(credentialsId: 'GITHUB_INTEGRATION', usernameVariable: 'GH_AUTH_USERNAME', passwordVariable: 'GH_AUTH_PASSWORD')]) {

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # This file was auto-generated, do not edit it directly.
 # Instead run bin/update_build_scripts from
 # https://github.com/sharelatex/sharelatex-dev-environment
-# Version: 1.1.24
+# Version: 1.3.5
 
 BUILD_NUMBER ?= local
 BRANCH_NAME ?= $(shell git rev-parse --abbrev-ref HEAD)
@@ -31,14 +31,20 @@ test_unit:
 
 test_acceptance: test_clean test_acceptance_pre_run test_acceptance_run
 
+test_acceptance_debug: test_clean test_acceptance_pre_run test_acceptance_run_debug
+
 test_acceptance_run:
 	@[ ! -d test/acceptance ] && echo "docstore has no acceptance tests" || $(DOCKER_COMPOSE) run --rm test_acceptance
+
+test_acceptance_run_debug:
+	@[ ! -d test/acceptance ] && echo "docstore has no acceptance tests" || $(DOCKER_COMPOSE) run -p 127.0.0.9:19999:19999 --rm test_acceptance npm run test:acceptance -- --inspect=0.0.0.0:19999 --inspect-brk
 
 test_clean:
 	$(DOCKER_COMPOSE) down -v -t 0
 
 test_acceptance_pre_run:
 	@[ ! -f test/acceptance/js/scripts/pre-run ] && echo "docstore has no pre acceptance tests task" || $(DOCKER_COMPOSE) run --rm test_acceptance test/acceptance/js/scripts/pre-run
+
 build:
 	docker build --pull --tag ci/$(PROJECT_NAME):$(BRANCH_NAME)-$(BUILD_NUMBER) \
 		--tag gcr.io/overleaf-ops/$(PROJECT_NAME):$(BRANCH_NAME)-$(BUILD_NUMBER) \
@@ -50,5 +56,6 @@ tar:
 publish:
 
 	docker push $(DOCKER_REPO)/$(PROJECT_NAME):$(BRANCH_NAME)-$(BUILD_NUMBER)
+
 
 .PHONY: clean test test_unit test_acceptance test_clean build publish

--- a/buildscript.txt
+++ b/buildscript.txt
@@ -1,10 +1,10 @@
 docstore
+--public-repo=True
 --language=coffeescript
+--env-add=
 --node-version=10.19.0
 --acceptance-creds=aws
 --dependencies=mongo,redis
 --docker-repos=gcr.io/overleaf-ops
---build-target=docker
---script-version=1.1.24
 --env-pass-through=
---public-repo=True
+--script-version=1.3.5

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,9 +1,9 @@
 # This file was auto-generated, do not edit it directly.
 # Instead run bin/update_build_scripts from
 # https://github.com/sharelatex/sharelatex-dev-environment
-# Version: 1.1.24
+# Version: 1.3.5
 
-version: "2"
+version: "2.3"
 
 services:
   test_unit:
@@ -28,11 +28,12 @@ services:
       MOCHA_GREP: ${MOCHA_GREP}
       NODE_ENV: test
     depends_on:
-      - mongo
-      - redis
+      mongo:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     user: node
     command: npm run test:acceptance:_run
-
 
 
   tar:
@@ -42,9 +43,8 @@ services:
       - ./:/tmp/build/
     command: tar -czf /tmp/build/build.tar.gz --exclude=build.tar.gz --exclude-vcs .
     user: root
-
   redis:
     image: redis
 
   mongo:
-    image: mongo:3.4
+    image: mongo:3.6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 # This file was auto-generated, do not edit it directly.
 # Instead run bin/update_build_scripts from
 # https://github.com/sharelatex/sharelatex-dev-environment
-# Version: 1.1.24
+# Version: 1.3.5
 
-version: "2"
+version: "2.3"
 
 services:
   test_unit:
@@ -18,7 +18,7 @@ services:
     user: node
 
   test_acceptance:
-    build: .
+    image: node:10.19.0
     volumes:
       - .:/app
     working_dir: /app
@@ -35,22 +35,15 @@ services:
       NODE_ENV: test
     user: node
     depends_on:
-      - mongo
-      - redis
+      mongo:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     command: npm run test:acceptance
-
-
-
-  tar:
-    build: .
-    image: ci/$PROJECT_NAME:$BRANCH_NAME-$BUILD_NUMBER
-    volumes:
-      - ./:/tmp/build/
-    command: tar -czf /tmp/build/build.tar.gz --exclude=build.tar.gz --exclude-vcs .
-    user: root
 
   redis:
     image: redis
 
   mongo:
-    image: mongo:3.4
+    image: mongo:3.6
+


### PR DESCRIPTION
### Description

Update the build scripts for https://github.com/overleaf/dev-environment/pull/294

This adds a new `base` stage for the docker image.

#### Related Issues / PRs

https://github.com/overleaf/dev-environment/pull/294

### Review

- `language=es`

  The eslint rules changed in the build-scripts, which required some formatting
   changes. These were automatically applied by `prettier-eslint --write`.

- `spelling`

  An additional tweak was required to cleanup a pending task for the unit-tests.

- `filestore`,  `spelling` and `third-party-datastore`

  See https://github.com/overleaf/dev-environment/pull/294#issuecomment-584777526
   for details on the added `data-dir` parameter.

#### Potential Impact

Low.

We will notice any complications in regards to starting the services in staging.