### PR TITLE
Make max doc length configurable via an env variable

### DIFF
--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -22,7 +22,7 @@ const Settings = {
     }
   },
 
-  max_doc_length: 2 * 1024 * 1024 // 2mb
+  max_doc_length: parseInt(process.env.MAX_DOC_LENGTH) || 2 * 1024 * 1024 // 2mb
 }
 
 if (process.env.MONGO_CONNECTION_STRING != null) {


### PR DESCRIPTION
### Description

Make max doc length configurable via an env variable.

#### Related Issues / PRs

* overleaf/issues#2726

### Review



#### Potential Impact

* Document updates

#### Manual Testing Performed

- [x] Test a doc upload with and without the env variable
- [x] Test a ridiculously low max doc length and see doc uploads fail

### Deployment



#### Deployment Checklist

- [ ] Test doc uploads again in staging

