### PR TITLE
[misc] test/unit: fix process usage for node v12

### DIFF
--- a/test/unit/js/HttpControllerTests.js
+++ b/test/unit/js/HttpControllerTests.js
@@ -32,7 +32,8 @@ describe('HttpController', function() {
           error: sinon.stub()
         }),
         './HealthChecker': {}
-      }
+      },
+      globals: { process }
     })
     this.res = {
       send: sinon.stub(),


### PR DESCRIPTION
### Description

Node 12 lazy loads `process`.  The sandbox module import does not play nice with that and we have to hard code it into the globals of the require call.

#### Related Issues / PRs

Similar patch from filestore: https://github.com/overleaf/filestore/pull/101/commits/1b408cc2572555712094b0a7a4ca651d6f99810f


#### Potential Impact

Low, affects unit tests only.

#### Who Needs to Know?

cc @jdleesmiller 