### PR TITLE
Format + Build Scripts 2.2

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,6 @@
 // this file was auto-generated, do not edit it directly.
 // instead run bin/update_build_scripts from
 // https://github.com/sharelatex/sharelatex-dev-environment
-// Version: 1.3.5
 {
   "extends": [
     "standard",

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,6 @@
 # This file was auto-generated, do not edit it directly.
 # Instead run bin/update_build_scripts from
 # https://github.com/sharelatex/sharelatex-dev-environment
-# Version: 1.3.5
 {
   "semi": false,
   "singleQuote": true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 # This file was auto-generated, do not edit it directly.
 # Instead run bin/update_build_scripts from
 # https://github.com/sharelatex/sharelatex-dev-environment
-# Version: 1.3.5
 
 FROM node:10.19.0 as base
 
@@ -12,7 +11,7 @@ FROM base as app
 #wildcard as some files may not be in all repos
 COPY package*.json npm-shrink*.json /app/
 
-RUN npm install --quiet
+RUN npm ci --quiet
 
 COPY . /app
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 # This file was auto-generated, do not edit it directly.
 # Instead run bin/update_build_scripts from
 # https://github.com/sharelatex/sharelatex-dev-environment
-# Version: 1.3.5
 
 BUILD_NUMBER ?= local
 BRANCH_NAME ?= $(shell git rev-parse --abbrev-ref HEAD)
 PROJECT_NAME = docstore
+BUILD_DIR_NAME = $(shell pwd | xargs basename | tr -cd '[a-zA-Z0-9_.\-]')
+
 DOCKER_COMPOSE_FLAGS ?= -f docker-compose.yml
 DOCKER_COMPOSE := BUILD_NUMBER=$(BUILD_NUMBER) \
 	BRANCH_NAME=$(BRANCH_NAME) \
@@ -15,6 +16,12 @@ DOCKER_COMPOSE := BUILD_NUMBER=$(BUILD_NUMBER) \
 	AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
 	AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
 	docker-compose ${DOCKER_COMPOSE_FLAGS}
+
+DOCKER_COMPOSE_TEST_ACCEPTANCE = \
+	COMPOSE_PROJECT_NAME=test_acceptance_$(BUILD_DIR_NAME) $(DOCKER_COMPOSE)
+
+DOCKER_COMPOSE_TEST_UNIT = \
+	COMPOSE_PROJECT_NAME=test_unit_$(BUILD_DIR_NAME) $(DOCKER_COMPOSE)
 
 clean:
 	docker rmi ci/$(PROJECT_NAME):$(BRANCH_NAME)-$(BUILD_NUMBER)
@@ -32,23 +39,41 @@ lint:
 test: format lint test_unit test_acceptance
 
 test_unit:
-	@[ ! -d test/unit ] && echo "docstore has no unit tests" || $(DOCKER_COMPOSE) run --rm test_unit
+ifneq (,$(wildcard test/unit))
+	$(DOCKER_COMPOSE_TEST_UNIT) run --rm test_unit
+	$(MAKE) test_unit_clean
+endif
 
-test_acceptance: test_clean test_acceptance_pre_run test_acceptance_run
+test_clean: test_unit_clean
+test_unit_clean:
+ifneq (,$(wildcard test/unit))
+	$(DOCKER_COMPOSE_TEST_UNIT) down -v -t 0
+endif
 
-test_acceptance_debug: test_clean test_acceptance_pre_run test_acceptance_run_debug
+test_acceptance: test_acceptance_clean test_acceptance_pre_run test_acceptance_run
+	$(MAKE) test_acceptance_clean
+
+test_acceptance_debug: test_acceptance_clean test_acceptance_pre_run test_acceptance_run_debug
+	$(MAKE) test_acceptance_clean
 
 test_acceptance_run:
-	@[ ! -d test/acceptance ] && echo "docstore has no acceptance tests" || $(DOCKER_COMPOSE) run --rm test_acceptance
+ifneq (,$(wildcard test/acceptance))
+	$(DOCKER_COMPOSE_TEST_ACCEPTANCE) run --rm test_acceptance
+endif
 
 test_acceptance_run_debug:
-	@[ ! -d test/acceptance ] && echo "docstore has no acceptance tests" || $(DOCKER_COMPOSE) run -p 127.0.0.9:19999:19999 --rm test_acceptance npm run test:acceptance -- --inspect=0.0.0.0:19999 --inspect-brk
+ifneq (,$(wildcard test/acceptance))
+	$(DOCKER_COMPOSE_TEST_ACCEPTANCE) run -p 127.0.0.9:19999:19999 --rm test_acceptance npm run test:acceptance -- --inspect=0.0.0.0:19999 --inspect-brk
+endif
 
-test_clean:
-	$(DOCKER_COMPOSE) down -v -t 0
+test_clean: test_acceptance_clean
+test_acceptance_clean:
+	$(DOCKER_COMPOSE_TEST_ACCEPTANCE) down -v -t 0
 
 test_acceptance_pre_run:
-	@[ ! -f test/acceptance/js/scripts/pre-run ] && echo "docstore has no pre acceptance tests task" || $(DOCKER_COMPOSE) run --rm test_acceptance test/acceptance/js/scripts/pre-run
+ifneq (,$(wildcard test/acceptance/js/scripts/pre-run))
+	$(DOCKER_COMPOSE_TEST_ACCEPTANCE) run --rm test_acceptance test/acceptance/js/scripts/pre-run
+endif
 
 build:
 	docker build --pull --tag ci/$(PROJECT_NAME):$(BRANCH_NAME)-$(BUILD_NUMBER) \

--- a/app.js
+++ b/app.js
@@ -24,7 +24,7 @@ app.use(Metrics.http.monitor(logger))
 
 Metrics.injectMetricsRoute(app)
 
-app.param('project_id', function(req, res, next, projectId) {
+app.param('project_id', function (req, res, next, projectId) {
   if (projectId != null ? projectId.match(/^[0-9a-f]{24}$/) : undefined) {
     return next()
   } else {
@@ -32,7 +32,7 @@ app.param('project_id', function(req, res, next, projectId) {
   }
 })
 
-app.param('doc_id', function(req, res, next, docId) {
+app.param('doc_id', function (req, res, next, docId) {
   if (docId != null ? docId.match(/^[0-9a-f]{24}$/) : undefined) {
     return next()
   } else {
@@ -62,7 +62,7 @@ app.get('/health_check', HttpController.healthCheck)
 
 app.get('/status', (req, res) => res.send('docstore is alive'))
 
-app.use(function(error, req, res, next) {
+app.use(function (error, req, res, next) {
   logger.error({ err: error, req }, 'request errored')
   if (error instanceof Errors.NotFoundError) {
     return res.send(404)
@@ -76,7 +76,7 @@ const { host } = Settings.internal.docstore
 
 if (!module.parent) {
   // Called directly
-  app.listen(port, host, function(error) {
+  app.listen(port, host, function (error) {
     if (error != null) {
       throw error
     }

--- a/app/js/DocManager.js
+++ b/app/js/DocManager.js
@@ -31,13 +31,16 @@ module.exports = DocManager = {
       filter = {}
     }
     if (callback == null) {
-      callback = function(error, doc) {}
+      callback = function (error, doc) {}
     }
     if (filter.inS3 !== true) {
       return callback('must include inS3 when getting doc')
     }
 
-    return MongoManager.findDoc(project_id, doc_id, filter, function(err, doc) {
+    return MongoManager.findDoc(project_id, doc_id, filter, function (
+      err,
+      doc
+    ) {
       if (err != null) {
         return callback(err)
       } else if (doc == null) {
@@ -47,7 +50,7 @@ module.exports = DocManager = {
           )
         )
       } else if (doc != null ? doc.inS3 : undefined) {
-        return DocArchive.unarchiveDoc(project_id, doc_id, function(err) {
+        return DocArchive.unarchiveDoc(project_id, doc_id, function (err) {
           if (err != null) {
             logger.err({ err, project_id, doc_id }, 'error unarchiving doc')
             return callback(err)
@@ -56,7 +59,7 @@ module.exports = DocManager = {
         })
       } else {
         if (filter.version) {
-          return MongoManager.getDocVersion(doc_id, function(error, version) {
+          return MongoManager.getDocVersion(doc_id, function (error, version) {
             if (error != null) {
               return callback(error)
             }
@@ -72,13 +75,13 @@ module.exports = DocManager = {
 
   checkDocExists(project_id, doc_id, callback) {
     if (callback == null) {
-      callback = function(err, exists) {}
+      callback = function (err, exists) {}
     }
     return DocManager._getDoc(
       project_id,
       doc_id,
       { _id: 1, inS3: true },
-      function(err, doc) {
+      function (err, doc) {
         if (err != null) {
           return callback(err)
         }
@@ -89,7 +92,7 @@ module.exports = DocManager = {
 
   getFullDoc(project_id, doc_id, callback) {
     if (callback == null) {
-      callback = function(err, doc) {}
+      callback = function (err, doc) {}
     }
     return DocManager._getDoc(
       project_id,
@@ -102,7 +105,7 @@ module.exports = DocManager = {
         ranges: true,
         inS3: true
       },
-      function(err, doc) {
+      function (err, doc) {
         if (err != null) {
           return callback(err)
         }
@@ -113,13 +116,13 @@ module.exports = DocManager = {
 
   getDocLines(project_id, doc_id, callback) {
     if (callback == null) {
-      callback = function(err, doc) {}
+      callback = function (err, doc) {}
     }
     return DocManager._getDoc(
       project_id,
       doc_id,
       { lines: true, inS3: true },
-      function(err, doc) {
+      function (err, doc) {
         if (err != null) {
           return callback(err)
         }
@@ -130,9 +133,9 @@ module.exports = DocManager = {
 
   getAllNonDeletedDocs(project_id, filter, callback) {
     if (callback == null) {
-      callback = function(error, docs) {}
+      callback = function (error, docs) {}
     }
-    return DocArchive.unArchiveAllDocs(project_id, function(error) {
+    return DocArchive.unArchiveAllDocs(project_id, function (error) {
       if (error != null) {
         return callback(error)
       }
@@ -140,7 +143,7 @@ module.exports = DocManager = {
         project_id,
         { include_deleted: false },
         filter,
-        function(error, docs) {
+        function (error, docs) {
           if (typeof err !== 'undefined' && err !== null) {
             return callback(error)
           } else if (docs == null) {
@@ -157,7 +160,7 @@ module.exports = DocManager = {
 
   updateDoc(project_id, doc_id, lines, version, ranges, callback) {
     if (callback == null) {
-      callback = function(error, modified, rev) {}
+      callback = function (error, modified, rev) {}
     }
     if (lines == null || version == null || ranges == null) {
       return callback(new Error('no lines, version or ranges provided'))
@@ -174,7 +177,7 @@ module.exports = DocManager = {
         ranges: true,
         inS3: true
       },
-      function(err, doc) {
+      function (err, doc) {
         let updateLines, updateRanges, updateVersion
         if (err != null && !(err instanceof Errors.NotFoundError)) {
           logger.err(
@@ -200,7 +203,7 @@ module.exports = DocManager = {
         let modified = false
         let rev = (doc != null ? doc.rev : undefined) || 0
 
-        const updateLinesAndRangesIfNeeded = function(cb) {
+        const updateLinesAndRangesIfNeeded = function (cb) {
           if (updateLines || updateRanges) {
             const update = {}
             if (updateLines) {
@@ -228,7 +231,7 @@ module.exports = DocManager = {
           }
         }
 
-        const updateVersionIfNeeded = function(cb) {
+        const updateVersionIfNeeded = function (cb) {
           if (updateVersion) {
             logger.log(
               {
@@ -250,11 +253,11 @@ module.exports = DocManager = {
           }
         }
 
-        return updateLinesAndRangesIfNeeded(function(error) {
+        return updateLinesAndRangesIfNeeded(function (error) {
           if (error != null) {
             return callback(error)
           }
-          return updateVersionIfNeeded(function(error) {
+          return updateVersionIfNeeded(function (error) {
             if (error != null) {
               return callback(error)
             }
@@ -267,9 +270,9 @@ module.exports = DocManager = {
 
   deleteDoc(project_id, doc_id, callback) {
     if (callback == null) {
-      callback = function(error) {}
+      callback = function (error) {}
     }
-    return DocManager.checkDocExists(project_id, doc_id, function(
+    return DocManager.checkDocExists(project_id, doc_id, function (
       error,
       exists
     ) {

--- a/app/js/Errors.js
+++ b/app/js/Errors.js
@@ -5,7 +5,7 @@
 // TODO: This file was created by bulk-decaffeinate.
 // Fix any style issues and re-enable lint.
 let Errors
-var NotFoundError = function(message) {
+var NotFoundError = function (message) {
   const error = new Error(message)
   error.name = 'NotFoundError'
   error.__proto__ = NotFoundError.prototype

--- a/app/js/HealthChecker.js
+++ b/app/js/HealthChecker.js
@@ -34,15 +34,15 @@ module.exports = {
     })
     logger.log({ lines, url, doc_id, project_id }, 'running health check')
     const jobs = [
-      function(cb) {
+      function (cb) {
         const opts = getOpts()
         opts.json = { lines, version: 42, ranges: {} }
         return request.post(opts, cb)
       },
-      function(cb) {
+      function (cb) {
         const opts = getOpts()
         opts.json = true
-        return request.get(opts, function(err, res, body) {
+        return request.get(opts, function (err, res, body) {
           if (err != null) {
             logger.err({ err }, 'docstore returned a error in health check get')
             return cb(err)
@@ -60,8 +60,8 @@ module.exports = {
           }
         })
       },
-      cb => db.docs.remove({ _id: doc_id, project_id }, cb),
-      cb => db.docOps.remove({ doc_id }, cb)
+      (cb) => db.docs.remove({ _id: doc_id, project_id }, cb),
+      (cb) => db.docOps.remove({ doc_id }, cb)
     ]
     return async.series(jobs, callback)
   }

--- a/app/js/HttpController.js
+++ b/app/js/HttpController.js
@@ -22,14 +22,14 @@ const Settings = require('settings-sharelatex')
 module.exports = HttpController = {
   getDoc(req, res, next) {
     if (next == null) {
-      next = function(error) {}
+      next = function (error) {}
     }
     const { project_id } = req.params
     const { doc_id } = req.params
     const include_deleted =
       (req.query != null ? req.query.include_deleted : undefined) === 'true'
     logger.log({ project_id, doc_id }, 'getting doc')
-    return DocManager.getFullDoc(project_id, doc_id, function(error, doc) {
+    return DocManager.getFullDoc(project_id, doc_id, function (error, doc) {
       if (error != null) {
         return next(error)
       }
@@ -46,12 +46,12 @@ module.exports = HttpController = {
 
   getRawDoc(req, res, next) {
     if (next == null) {
-      next = function(error) {}
+      next = function (error) {}
     }
     const { project_id } = req.params
     const { doc_id } = req.params
     logger.log({ project_id, doc_id }, 'getting raw doc')
-    return DocManager.getDocLines(project_id, doc_id, function(error, doc) {
+    return DocManager.getDocLines(project_id, doc_id, function (error, doc) {
       if (error != null) {
         return next(error)
       }
@@ -66,14 +66,14 @@ module.exports = HttpController = {
 
   getAllDocs(req, res, next) {
     if (next == null) {
-      next = function(error) {}
+      next = function (error) {}
     }
     const { project_id } = req.params
     logger.log({ project_id }, 'getting all docs')
     return DocManager.getAllNonDeletedDocs(
       project_id,
       { lines: true, rev: true },
-      function(error, docs) {
+      function (error, docs) {
         if (docs == null) {
           docs = []
         }
@@ -87,14 +87,14 @@ module.exports = HttpController = {
 
   getAllRanges(req, res, next) {
     if (next == null) {
-      next = function(error) {}
+      next = function (error) {}
     }
     const { project_id } = req.params
     logger.log({ project_id }, 'getting all ranges')
     return DocManager.getAllNonDeletedDocs(
       project_id,
       { ranges: true },
-      function(error, docs) {
+      function (error, docs) {
         if (docs == null) {
           docs = []
         }
@@ -108,7 +108,7 @@ module.exports = HttpController = {
 
   updateDoc(req, res, next) {
     if (next == null) {
-      next = function(error) {}
+      next = function (error) {}
     }
     const { project_id } = req.params
     const { doc_id } = req.params
@@ -151,7 +151,7 @@ module.exports = HttpController = {
       lines,
       version,
       ranges,
-      function(error, modified, rev) {
+      function (error, modified, rev) {
         if (error != null) {
           return next(error)
         }
@@ -165,12 +165,12 @@ module.exports = HttpController = {
 
   deleteDoc(req, res, next) {
     if (next == null) {
-      next = function(error) {}
+      next = function (error) {}
     }
     const { project_id } = req.params
     const { doc_id } = req.params
     logger.log({ project_id, doc_id }, 'deleting doc')
-    return DocManager.deleteDoc(project_id, doc_id, function(error) {
+    return DocManager.deleteDoc(project_id, doc_id, function (error) {
       if (error != null) {
         return next(error)
       }
@@ -210,11 +210,11 @@ module.exports = HttpController = {
 
   archiveAllDocs(req, res, next) {
     if (next == null) {
-      next = function(error) {}
+      next = function (error) {}
     }
     const { project_id } = req.params
     logger.log({ project_id }, 'archiving all docs')
-    return DocArchive.archiveAllDocs(project_id, function(error) {
+    return DocArchive.archiveAllDocs(project_id, function (error) {
       if (error != null) {
         return next(error)
       }
@@ -224,11 +224,11 @@ module.exports = HttpController = {
 
   unArchiveAllDocs(req, res, next) {
     if (next == null) {
-      next = function(error) {}
+      next = function (error) {}
     }
     const { project_id } = req.params
     logger.log({ project_id }, 'unarchiving all docs')
-    return DocArchive.unArchiveAllDocs(project_id, function(error) {
+    return DocArchive.unArchiveAllDocs(project_id, function (error) {
       if (error != null) {
         return next(error)
       }
@@ -238,11 +238,11 @@ module.exports = HttpController = {
 
   destroyAllDocs(req, res, next) {
     if (next == null) {
-      next = function(error) {}
+      next = function (error) {}
     }
     const { project_id } = req.params
     logger.log({ project_id }, 'destroying all docs')
-    return DocArchive.destroyAllDocs(project_id, function(error) {
+    return DocArchive.destroyAllDocs(project_id, function (error) {
       if (error != null) {
         return next(error)
       }
@@ -251,7 +251,7 @@ module.exports = HttpController = {
   },
 
   healthCheck(req, res) {
-    return HealthChecker.check(function(err) {
+    return HealthChecker.check(function (err) {
       if (err != null) {
         logger.err({ err }, 'error performing health check')
         return res.send(500)

--- a/app/js/MongoManager.js
+++ b/app/js/MongoManager.js
@@ -18,7 +18,7 @@ const metrics = require('metrics-sharelatex')
 module.exports = MongoManager = {
   findDoc(project_id, doc_id, filter, callback) {
     if (callback == null) {
-      callback = function(error, doc) {}
+      callback = function (error, doc) {}
     }
     return db.docs.find(
       {
@@ -26,7 +26,7 @@ module.exports = MongoManager = {
         project_id: ObjectId(project_id.toString())
       },
       filter,
-      function(error, docs) {
+      function (error, docs) {
         if (docs == null) {
           docs = []
         }
@@ -98,12 +98,12 @@ module.exports = MongoManager = {
       _id: doc_id,
       rev
     }
-    return db.docs.update(query, update, err => callback(err))
+    return db.docs.update(query, update, (err) => callback(err))
   },
 
   getDocVersion(doc_id, callback) {
     if (callback == null) {
-      callback = function(error, version) {}
+      callback = function (error, version) {}
     }
     return db.docOps.find(
       {
@@ -112,7 +112,7 @@ module.exports = MongoManager = {
       {
         version: 1
       },
-      function(error, docs) {
+      function (error, docs) {
         if (error != null) {
           return callback(error)
         }
@@ -127,7 +127,7 @@ module.exports = MongoManager = {
 
   setDocVersion(doc_id, version, callback) {
     if (callback == null) {
-      callback = function(error) {}
+      callback = function (error) {}
     }
     return db.docOps.update(
       {
@@ -148,7 +148,7 @@ module.exports = MongoManager = {
       {
         _id: ObjectId(doc_id)
       },
-      function(err) {
+      function (err) {
         if (err != null) {
           return callback(err)
         }
@@ -170,6 +170,6 @@ module.exports = MongoManager = {
   'markDocAsArchived',
   'getDocVersion',
   'setDocVersion'
-].map(method =>
+].map((method) =>
   metrics.timeAsyncMethod(MongoManager, method, 'mongo.MongoManager', logger)
 )

--- a/app/js/RangeManager.js
+++ b/app/js/RangeManager.js
@@ -36,7 +36,7 @@ module.exports = RangeManager = {
       return null
     }
 
-    const updateMetadata = function(metadata) {
+    const updateMetadata = function (metadata) {
       if ((metadata != null ? metadata.ts : undefined) != null) {
         metadata.ts = new Date(metadata.ts)
       }

--- a/buildscript.txt
+++ b/buildscript.txt
@@ -1,10 +1,10 @@
 docstore
---node-version=10.19.0
---script-version=1.3.5
---dependencies=mongo
---language=es
---docker-repos=gcr.io/overleaf-ops
 --acceptance-creds=aws
---env-pass-through=
+--dependencies=mongo
+--docker-repos=gcr.io/overleaf-ops
 --env-add=
+--env-pass-through=
+--language=es
+--node-version=10.19.0
 --public-repo=True
+--script-version=2.2.0

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,7 +1,6 @@
 # This file was auto-generated, do not edit it directly.
 # Instead run bin/update_build_scripts from
 # https://github.com/sharelatex/sharelatex-dev-environment
-# Version: 1.3.5
 
 version: "2.3"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 # This file was auto-generated, do not edit it directly.
 # Instead run bin/update_build_scripts from
 # https://github.com/sharelatex/sharelatex-dev-environment
-# Version: 1.3.5
 
 version: "2.3"
 

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "test:unit": "npm run test:unit:_run -- --grep=$MOCHA_GREP",
     "nodemon": "nodemon --config nodemon.json",
     "lint": "node_modules/.bin/eslint .",
-    "format": "node_modules/.bin/prettier-eslint '**/*.js' --list-different",
-    "format:fix": "node_modules/.bin/prettier-eslint '**/*.js' --write"
+    "format": "node_modules/.bin/prettier-eslint $PWD'/**/*.js' --list-different",
+    "format:fix": "node_modules/.bin/prettier-eslint $PWD'/**/*.js' --write"
   },
   "dependencies": {
     "async": "^2.6.3",
@@ -33,8 +33,8 @@
     "bunyan": "~1.8.12",
     "chai": "~4.2.0",
     "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.10.1",
-    "eslint-config-standard": "^14.1.1",
+    "eslint-config-prettier": "^6.10.0",
+    "eslint-config-standard": "^14.1.0",
     "eslint-config-standard-jsx": "^8.1.0",
     "eslint-config-standard-react": "^9.2.0",
     "eslint-plugin-chai-expect": "^2.1.0",

--- a/test/acceptance/js/ArchiveDocsTests.js
+++ b/test/acceptance/js/ArchiveDocsTests.js
@@ -23,13 +23,13 @@ const request = require('request')
 const DocstoreApp = require('./helpers/DocstoreApp')
 const DocstoreClient = require('./helpers/DocstoreClient')
 
-describe('Archiving', function() {
-  before(function(done) {
+describe('Archiving', function () {
+  before(function (done) {
     return DocstoreApp.ensureRunning(done)
   })
 
-  describe('multiple docs in a project', function() {
-    before(function(done) {
+  describe('multiple docs in a project', function () {
+    before(function (done) {
       this.project_id = ObjectId()
       this.docs = [
         {
@@ -45,9 +45,9 @@ describe('Archiving', function() {
           version: 4
         }
       ]
-      const jobs = Array.from(this.docs).map(doc =>
-        (doc => {
-          return callback => {
+      const jobs = Array.from(this.docs).map((doc) =>
+        ((doc) => {
+          return (callback) => {
             return DocstoreClient.createDoc(
               this.project_id,
               doc._id,
@@ -60,7 +60,7 @@ describe('Archiving', function() {
         })(doc)
       )
 
-      return async.series(jobs, error => {
+      return async.series(jobs, (error) => {
         if (error != null) {
           throw error
         }
@@ -71,15 +71,15 @@ describe('Archiving', function() {
       })
     })
 
-    it('should archive all the docs', function(done) {
+    it('should archive all the docs', function (done) {
       this.res.statusCode.should.equal(204)
       return done()
     })
 
-    it('should set inS3 and unset lines and ranges in each doc', function(done) {
-      const jobs = Array.from(this.docs).map(doc =>
-        (doc => {
-          return callback => {
+    it('should set inS3 and unset lines and ranges in each doc', function (done) {
+      const jobs = Array.from(this.docs).map((doc) =>
+        ((doc) => {
+          return (callback) => {
             return db.docs.findOne({ _id: doc._id }, (error, doc) => {
               should.not.exist(doc.lines)
               should.not.exist(doc.ranges)
@@ -92,10 +92,10 @@ describe('Archiving', function() {
       return async.series(jobs, done)
     })
 
-    it('should set the docs in s3 correctly', function(done) {
-      const jobs = Array.from(this.docs).map(doc =>
-        (doc => {
-          return callback => {
+    it('should set the docs in s3 correctly', function (done) {
+      const jobs = Array.from(this.docs).map((doc) =>
+        ((doc) => {
+          return (callback) => {
             return DocstoreClient.getS3Doc(
               this.project_id,
               doc._id,
@@ -111,8 +111,8 @@ describe('Archiving', function() {
       return async.series(jobs, done)
     })
 
-    return describe('after unarchiving from a request for the project', function() {
-      before(function(done) {
+    return describe('after unarchiving from a request for the project', function () {
+      before(function (done) {
         return DocstoreClient.getAllDocs(
           this.project_id,
           (error, res, fetched_docs) => {
@@ -125,7 +125,7 @@ describe('Archiving', function() {
         )
       })
 
-      it('should return the docs', function(done) {
+      it('should return the docs', function (done) {
         for (let i = 0; i < this.fetched_docs.length; i++) {
           const doc = this.fetched_docs[i]
           doc.lines.should.deep.equal(this.docs[i].lines)
@@ -133,10 +133,10 @@ describe('Archiving', function() {
         return done()
       })
 
-      return it('should restore the docs to mongo', function(done) {
+      return it('should restore the docs to mongo', function (done) {
         const jobs = Array.from(this.docs).map((doc, i) =>
           ((doc, i) => {
-            return callback => {
+            return (callback) => {
               return db.docs.findOne({ _id: doc._id }, (error, doc) => {
                 doc.lines.should.deep.equal(this.docs[i].lines)
                 doc.ranges.should.deep.equal(this.docs[i].ranges)
@@ -151,8 +151,8 @@ describe('Archiving', function() {
     })
   })
 
-  describe('a deleted doc', function() {
-    before(function(done) {
+  describe('a deleted doc', function () {
+    before(function (done) {
       this.project_id = ObjectId()
       this.doc = {
         _id: ObjectId(),
@@ -166,14 +166,14 @@ describe('Archiving', function() {
         this.doc.lines,
         this.doc.version,
         this.doc.ranges,
-        error => {
+        (error) => {
           if (error != null) {
             throw error
           }
           return DocstoreClient.deleteDoc(
             this.project_id,
             this.doc._id,
-            error => {
+            (error) => {
               if (error != null) {
                 throw error
               }
@@ -193,12 +193,12 @@ describe('Archiving', function() {
       )
     })
 
-    it('should successully archive the docs', function(done) {
+    it('should successully archive the docs', function (done) {
       this.res.statusCode.should.equal(204)
       return done()
     })
 
-    it('should set inS3 and unset lines and ranges in each doc', function(done) {
+    it('should set inS3 and unset lines and ranges in each doc', function (done) {
       return db.docs.findOne({ _id: this.doc._id }, (error, doc) => {
         if (error != null) {
           throw error
@@ -211,7 +211,7 @@ describe('Archiving', function() {
       })
     })
 
-    it('should set the doc in s3 correctly', function(done) {
+    it('should set the doc in s3 correctly', function (done) {
       return DocstoreClient.getS3Doc(
         this.project_id,
         this.doc._id,
@@ -226,8 +226,8 @@ describe('Archiving', function() {
       )
     })
 
-    return describe('after unarchiving from a request for the project', function() {
-      before(function(done) {
+    return describe('after unarchiving from a request for the project', function () {
+      before(function (done) {
         return DocstoreClient.getAllDocs(
           this.project_id,
           (error, res, fetched_docs) => {
@@ -240,12 +240,12 @@ describe('Archiving', function() {
         )
       })
 
-      it('should not included the deleted', function(done) {
+      it('should not included the deleted', function (done) {
         this.fetched_docs.length.should.equal(0)
         return done()
       })
 
-      return it('should restore the doc to mongo', function(done) {
+      return it('should restore the doc to mongo', function (done) {
         return db.docs.findOne({ _id: this.doc._id }, (error, doc) => {
           if (error != null) {
             throw error
@@ -260,8 +260,8 @@ describe('Archiving', function() {
     })
   })
 
-  describe('a doc with large lines', function() {
-    before(function(done) {
+  describe('a doc with large lines', function () {
+    before(function (done) {
       this.project_id = ObjectId()
       this.timeout(1000 * 30)
       const quarterMegInBytes = 250000
@@ -280,7 +280,7 @@ describe('Archiving', function() {
         this.doc.lines,
         this.doc.version,
         this.doc.ranges,
-        error => {
+        (error) => {
           if (error != null) {
             throw error
           }
@@ -295,12 +295,12 @@ describe('Archiving', function() {
       )
     })
 
-    it('should successully archive the docs', function(done) {
+    it('should successully archive the docs', function (done) {
       this.res.statusCode.should.equal(204)
       return done()
     })
 
-    it('should set inS3 and unset lines and ranges in each doc', function(done) {
+    it('should set inS3 and unset lines and ranges in each doc', function (done) {
       return db.docs.findOne({ _id: this.doc._id }, (error, doc) => {
         if (error != null) {
           throw error
@@ -312,7 +312,7 @@ describe('Archiving', function() {
       })
     })
 
-    it('should set the doc in s3 correctly', function(done) {
+    it('should set the doc in s3 correctly', function (done) {
       return DocstoreClient.getS3Doc(
         this.project_id,
         this.doc._id,
@@ -327,8 +327,8 @@ describe('Archiving', function() {
       )
     })
 
-    return describe('after unarchiving from a request for the project', function() {
-      before(function(done) {
+    return describe('after unarchiving from a request for the project', function () {
+      before(function (done) {
         return DocstoreClient.getAllDocs(
           this.project_id,
           (error, res, fetched_docs) => {
@@ -341,7 +341,7 @@ describe('Archiving', function() {
         )
       })
 
-      return it('should restore the doc to mongo', function(done) {
+      return it('should restore the doc to mongo', function (done) {
         return db.docs.findOne({ _id: this.doc._id }, (error, doc) => {
           if (error != null) {
             throw error
@@ -355,8 +355,8 @@ describe('Archiving', function() {
     })
   })
 
-  describe('a doc with naughty strings', function() {
-    before(function(done) {
+  describe('a doc with naughty strings', function () {
+    before(function (done) {
       this.project_id = ObjectId()
       this.doc = {
         _id: ObjectId(),
@@ -754,7 +754,7 @@ describe('Archiving', function() {
         this.doc.lines,
         this.doc.version,
         this.doc.ranges,
-        error => {
+        (error) => {
           if (error != null) {
             throw error
           }
@@ -769,12 +769,12 @@ describe('Archiving', function() {
       )
     })
 
-    it('should successully archive the docs', function(done) {
+    it('should successully archive the docs', function (done) {
       this.res.statusCode.should.equal(204)
       return done()
     })
 
-    it('should set inS3 and unset lines and ranges in each doc', function(done) {
+    it('should set inS3 and unset lines and ranges in each doc', function (done) {
       return db.docs.findOne({ _id: this.doc._id }, (error, doc) => {
         if (error != null) {
           throw error
@@ -786,7 +786,7 @@ describe('Archiving', function() {
       })
     })
 
-    it('should set the doc in s3 correctly', function(done) {
+    it('should set the doc in s3 correctly', function (done) {
       return DocstoreClient.getS3Doc(
         this.project_id,
         this.doc._id,
@@ -801,8 +801,8 @@ describe('Archiving', function() {
       )
     })
 
-    return describe('after unarchiving from a request for the project', function() {
-      before(function(done) {
+    return describe('after unarchiving from a request for the project', function () {
+      before(function (done) {
         return DocstoreClient.getAllDocs(
           this.project_id,
           (error, res, fetched_docs) => {
@@ -815,7 +815,7 @@ describe('Archiving', function() {
         )
       })
 
-      return it('should restore the doc to mongo', function(done) {
+      return it('should restore the doc to mongo', function (done) {
         return db.docs.findOne({ _id: this.doc._id }, (error, doc) => {
           if (error != null) {
             throw error
@@ -829,8 +829,8 @@ describe('Archiving', function() {
     })
   })
 
-  describe('a doc with ranges', function() {
-    before(function(done) {
+  describe('a doc with ranges', function () {
+    before(function (done) {
       this.project_id = ObjectId()
       this.doc = {
         _id: ObjectId(),
@@ -873,7 +873,7 @@ describe('Archiving', function() {
         this.doc.lines,
         this.doc.version,
         this.doc.ranges,
-        error => {
+        (error) => {
           if (error != null) {
             throw error
           }
@@ -888,12 +888,12 @@ describe('Archiving', function() {
       )
     })
 
-    it('should successully archive the docs', function(done) {
+    it('should successully archive the docs', function (done) {
       this.res.statusCode.should.equal(204)
       return done()
     })
 
-    it('should set inS3 and unset lines and ranges in each doc', function(done) {
+    it('should set inS3 and unset lines and ranges in each doc', function (done) {
       return db.docs.findOne({ _id: this.doc._id }, (error, doc) => {
         if (error != null) {
           throw error
@@ -905,7 +905,7 @@ describe('Archiving', function() {
       })
     })
 
-    it('should set the doc in s3 correctly', function(done) {
+    it('should set the doc in s3 correctly', function (done) {
       return DocstoreClient.getS3Doc(
         this.project_id,
         this.doc._id,
@@ -921,8 +921,8 @@ describe('Archiving', function() {
       )
     })
 
-    return describe('after unarchiving from a request for the project', function() {
-      before(function(done) {
+    return describe('after unarchiving from a request for the project', function () {
+      before(function (done) {
         return DocstoreClient.getAllDocs(
           this.project_id,
           (error, res, fetched_docs) => {
@@ -935,7 +935,7 @@ describe('Archiving', function() {
         )
       })
 
-      return it('should restore the doc to mongo', function(done) {
+      return it('should restore the doc to mongo', function (done) {
         return db.docs.findOne({ _id: this.doc._id }, (error, doc) => {
           if (error != null) {
             throw error
@@ -949,8 +949,8 @@ describe('Archiving', function() {
     })
   })
 
-  describe('a doc that is archived twice', function() {
-    before(function(done) {
+  describe('a doc that is archived twice', function () {
+    before(function (done) {
       this.project_id = ObjectId()
       this.doc = {
         _id: ObjectId(),
@@ -964,7 +964,7 @@ describe('Archiving', function() {
         this.doc.lines,
         this.doc.version,
         this.doc.ranges,
-        error => {
+        (error) => {
           if (error != null) {
             throw error
           }
@@ -990,7 +990,7 @@ describe('Archiving', function() {
       )
     })
 
-    it('should set inS3 and unset lines and ranges in each doc', function(done) {
+    it('should set inS3 and unset lines and ranges in each doc', function (done) {
       return db.docs.findOne({ _id: this.doc._id }, (error, doc) => {
         if (error != null) {
           throw error
@@ -1002,7 +1002,7 @@ describe('Archiving', function() {
       })
     })
 
-    it('should set the doc in s3 correctly', function(done) {
+    it('should set the doc in s3 correctly', function (done) {
       return DocstoreClient.getS3Doc(
         this.project_id,
         this.doc._id,
@@ -1017,8 +1017,8 @@ describe('Archiving', function() {
       )
     })
 
-    return describe('after unarchiving from a request for the project', function() {
-      before(function(done) {
+    return describe('after unarchiving from a request for the project', function () {
+      before(function (done) {
         return DocstoreClient.getAllDocs(
           this.project_id,
           (error, res, fetched_docs) => {
@@ -1031,7 +1031,7 @@ describe('Archiving', function() {
         )
       })
 
-      return it('should restore the doc to mongo', function(done) {
+      return it('should restore the doc to mongo', function (done) {
         return db.docs.findOne({ _id: this.doc._id }, (error, doc) => {
           if (error != null) {
             throw error
@@ -1045,8 +1045,8 @@ describe('Archiving', function() {
     })
   })
 
-  return describe('a doc with the old schema (just an array of lines)', function() {
-    before(function(done) {
+  return describe('a doc with the old schema (just an array of lines)', function () {
+    before(function (done) {
       this.project_id = ObjectId()
       this.doc = {
         _id: ObjectId(),
@@ -1070,7 +1070,7 @@ describe('Archiving', function() {
             rev: this.doc.version,
             inS3: true
           },
-          error => {
+          (error) => {
             if (error != null) {
               throw error
             }
@@ -1089,7 +1089,7 @@ describe('Archiving', function() {
       })
     })
 
-    it('should restore the doc to mongo', function(done) {
+    it('should restore the doc to mongo', function (done) {
       return db.docs.findOne({ _id: this.doc._id }, (error, doc) => {
         if (error != null) {
           throw error
@@ -1100,7 +1100,7 @@ describe('Archiving', function() {
       })
     })
 
-    return it('should return the doc', function(done) {
+    return it('should return the doc', function (done) {
       this.fetched_docs[0].lines.should.deep.equal(this.doc.lines)
       return done()
     })

--- a/test/acceptance/js/DeletingDocsTests.js
+++ b/test/acceptance/js/DeletingDocsTests.js
@@ -20,8 +20,8 @@ const DocstoreApp = require('./helpers/DocstoreApp')
 
 const DocstoreClient = require('./helpers/DocstoreClient')
 
-describe('Deleting a doc', function() {
-  beforeEach(function(done) {
+describe('Deleting a doc', function () {
+  beforeEach(function (done) {
     this.project_id = ObjectId()
     this.doc_id = ObjectId()
     this.lines = ['original', 'lines']
@@ -34,7 +34,7 @@ describe('Deleting a doc', function() {
         this.lines,
         this.version,
         this.ranges,
-        error => {
+        (error) => {
           if (error != null) {
             throw error
           }
@@ -44,8 +44,8 @@ describe('Deleting a doc', function() {
     })
   })
 
-  describe('when the doc exists', function() {
-    beforeEach(function(done) {
+  describe('when the doc exists', function () {
+    beforeEach(function (done) {
       return DocstoreClient.deleteDoc(
         this.project_id,
         this.doc_id,
@@ -56,11 +56,11 @@ describe('Deleting a doc', function() {
       )
     })
 
-    afterEach(function(done) {
+    afterEach(function (done) {
       return db.docs.remove({ _id: this.doc_id }, done)
     })
 
-    return it('should insert a deleted doc into the docs collection', function(done) {
+    return it('should insert a deleted doc into the docs collection', function (done) {
       return db.docs.find({ _id: this.doc_id }, (error, docs) => {
         docs[0]._id.should.deep.equal(this.doc_id)
         docs[0].lines.should.deep.equal(this.lines)
@@ -70,8 +70,8 @@ describe('Deleting a doc', function() {
     })
   })
 
-  return describe('when the doc does not exist', function() {
-    return it('should return a 404', function(done) {
+  return describe('when the doc does not exist', function () {
+    return it('should return a 404', function (done) {
       const missing_doc_id = ObjectId()
       return DocstoreClient.deleteDoc(
         this.project_id,
@@ -85,12 +85,12 @@ describe('Deleting a doc', function() {
   })
 })
 
-describe("Destroying a project's documents", function() {
-  describe('when the doc exists', function() {
-    beforeEach(function(done) {
+describe("Destroying a project's documents", function () {
+  describe('when the doc exists', function () {
+    beforeEach(function (done) {
       return db.docOps.insert(
         { doc_id: ObjectId(this.doc_id), version: 1 },
-        function(err) {
+        function (err) {
           if (err != null) {
             return done(err)
           }
@@ -99,7 +99,7 @@ describe("Destroying a project's documents", function() {
       )
     })
 
-    it('should remove the doc from the docs collection', function(done) {
+    it('should remove the doc from the docs collection', function (done) {
       return db.docs.find({ _id: this.doc_id }, (err, docs) => {
         expect(err).not.to.exist
         expect(docs).to.deep.equal([])
@@ -107,7 +107,7 @@ describe("Destroying a project's documents", function() {
       })
     })
 
-    return it('should remove the docOps from the docOps collection', function(done) {
+    return it('should remove the docOps from the docOps collection', function (done) {
       return db.docOps.find({ doc_id: this.doc_id }, (err, docOps) => {
         expect(err).not.to.exist
         expect(docOps).to.deep.equal([])
@@ -116,9 +116,9 @@ describe("Destroying a project's documents", function() {
     })
   })
 
-  return describe('when the doc is archived', function() {
-    beforeEach(function(done) {
-      return DocstoreClient.archiveAllDoc(this.project_id, function(err) {
+  return describe('when the doc is archived', function () {
+    beforeEach(function (done) {
+      return DocstoreClient.archiveAllDoc(this.project_id, function (err) {
         if (err != null) {
           return done(err)
         }
@@ -126,7 +126,7 @@ describe("Destroying a project's documents", function() {
       })
     })
 
-    it('should remove the doc from the docs collection', function(done) {
+    it('should remove the doc from the docs collection', function (done) {
       return db.docs.find({ _id: this.doc_id }, (err, docs) => {
         expect(err).not.to.exist
         expect(docs).to.deep.equal([])
@@ -134,7 +134,7 @@ describe("Destroying a project's documents", function() {
       })
     })
 
-    it('should remove the docOps from the docOps collection', function(done) {
+    it('should remove the docOps from the docOps collection', function (done) {
       return db.docOps.find({ doc_id: this.doc_id }, (err, docOps) => {
         expect(err).not.to.exist
         expect(docOps).to.deep.equal([])
@@ -142,7 +142,7 @@ describe("Destroying a project's documents", function() {
       })
     })
 
-    return it('should remove the doc contents from s3', function(done) {
+    return it('should remove the doc contents from s3', function (done) {
       return DocstoreClient.getS3Doc(
         this.project_id,
         this.doc_id,

--- a/test/acceptance/js/GettingAllDocsTests.js
+++ b/test/acceptance/js/GettingAllDocsTests.js
@@ -20,8 +20,8 @@ const DocstoreApp = require('./helpers/DocstoreApp')
 
 const DocstoreClient = require('./helpers/DocstoreClient')
 
-describe('Getting all docs', function() {
-  beforeEach(function(done) {
+describe('Getting all docs', function () {
+  beforeEach(function (done) {
     this.project_id = ObjectId()
     this.docs = [
       {
@@ -50,9 +50,9 @@ describe('Getting all docs', function() {
       rev: 8
     }
     const version = 42
-    const jobs = Array.from(this.docs).map(doc =>
-      (doc => {
-        return callback => {
+    const jobs = Array.from(this.docs).map((doc) =>
+      ((doc) => {
+        return (callback) => {
           return DocstoreClient.createDoc(
             this.project_id,
             doc._id,
@@ -64,14 +64,14 @@ describe('Getting all docs', function() {
         }
       })(doc)
     )
-    jobs.push(cb => {
+    jobs.push((cb) => {
       return DocstoreClient.createDoc(
         this.project_id,
         this.deleted_doc._id,
         this.deleted_doc.lines,
         version,
         this.deleted_doc.ranges,
-        err => {
+        (err) => {
           return DocstoreClient.deleteDoc(
             this.project_id,
             this.deleted_doc._id,
@@ -80,11 +80,11 @@ describe('Getting all docs', function() {
         }
       )
     })
-    jobs.unshift(cb => DocstoreApp.ensureRunning(cb))
+    jobs.unshift((cb) => DocstoreApp.ensureRunning(cb))
     return async.series(jobs, done)
   })
 
-  it('getAllDocs should return all the (non-deleted) docs', function(done) {
+  it('getAllDocs should return all the (non-deleted) docs', function (done) {
     return DocstoreClient.getAllDocs(this.project_id, (error, res, docs) => {
       if (error != null) {
         throw error
@@ -98,7 +98,7 @@ describe('Getting all docs', function() {
     })
   })
 
-  return it('getAllRanges should return all the (non-deleted) doc ranges', function(done) {
+  return it('getAllRanges should return all the (non-deleted) doc ranges', function (done) {
     return DocstoreClient.getAllRanges(this.project_id, (error, res, docs) => {
       if (error != null) {
         throw error

--- a/test/acceptance/js/GettingDocsTests.js
+++ b/test/acceptance/js/GettingDocsTests.js
@@ -19,8 +19,8 @@ const DocstoreApp = require('./helpers/DocstoreApp')
 
 const DocstoreClient = require('./helpers/DocstoreClient')
 
-describe('Getting a doc', function() {
-  beforeEach(function(done) {
+describe('Getting a doc', function () {
+  beforeEach(function (done) {
     this.project_id = ObjectId()
     this.doc_id = ObjectId()
     this.lines = ['original', 'lines']
@@ -44,7 +44,7 @@ describe('Getting a doc', function() {
         this.lines,
         this.version,
         this.ranges,
-        error => {
+        (error) => {
           if (error != null) {
             throw error
           }
@@ -54,8 +54,8 @@ describe('Getting a doc', function() {
     })
   })
 
-  describe('when the doc exists', function() {
-    return it('should get the doc lines and version', function(done) {
+  describe('when the doc exists', function () {
+    return it('should get the doc lines and version', function (done) {
       return DocstoreClient.getDoc(
         this.project_id,
         this.doc_id,
@@ -70,8 +70,8 @@ describe('Getting a doc', function() {
     })
   })
 
-  describe('when the doc does not exist', function() {
-    return it('should return a 404', function(done) {
+  describe('when the doc does not exist', function () {
+    return it('should return a 404', function (done) {
       const missing_doc_id = ObjectId()
       return DocstoreClient.getDoc(
         this.project_id,
@@ -85,8 +85,8 @@ describe('Getting a doc', function() {
     })
   })
 
-  return describe('when the doc is a deleted doc', function() {
-    beforeEach(function(done) {
+  return describe('when the doc is a deleted doc', function () {
+    beforeEach(function (done) {
       this.deleted_doc_id = ObjectId()
       return DocstoreClient.createDoc(
         this.project_id,
@@ -94,7 +94,7 @@ describe('Getting a doc', function() {
         this.lines,
         this.version,
         this.ranges,
-        error => {
+        (error) => {
           if (error != null) {
             throw error
           }
@@ -107,7 +107,7 @@ describe('Getting a doc', function() {
       )
     })
 
-    it('should return the doc', function(done) {
+    it('should return the doc', function (done) {
       return DocstoreClient.getDoc(
         this.project_id,
         this.deleted_doc_id,
@@ -122,7 +122,7 @@ describe('Getting a doc', function() {
       )
     })
 
-    return it('should return a 404 when the query string is not set', function(done) {
+    return it('should return a 404 when the query string is not set', function (done) {
       return DocstoreClient.getDoc(
         this.project_id,
         this.deleted_doc_id,

--- a/test/acceptance/js/UpdatingDocsTests.js
+++ b/test/acceptance/js/UpdatingDocsTests.js
@@ -18,8 +18,8 @@ const DocstoreApp = require('./helpers/DocstoreApp')
 
 const DocstoreClient = require('./helpers/DocstoreClient')
 
-describe('Applying updates to a doc', function() {
-  beforeEach(function(done) {
+describe('Applying updates to a doc', function () {
+  beforeEach(function (done) {
     this.project_id = ObjectId()
     this.doc_id = ObjectId()
     this.originalLines = ['original', 'lines']
@@ -56,7 +56,7 @@ describe('Applying updates to a doc', function() {
         this.originalLines,
         this.version,
         this.originalRanges,
-        error => {
+        (error) => {
           if (error != null) {
             throw error
           }
@@ -66,8 +66,8 @@ describe('Applying updates to a doc', function() {
     })
   })
 
-  describe('when nothing has been updated', function() {
-    beforeEach(function(done) {
+  describe('when nothing has been updated', function () {
+    beforeEach(function (done) {
       return DocstoreClient.updateDoc(
         this.project_id,
         this.doc_id,
@@ -81,11 +81,11 @@ describe('Applying updates to a doc', function() {
       )
     })
 
-    it('should return modified = false', function() {
+    it('should return modified = false', function () {
       return this.body.modified.should.equal(false)
     })
 
-    return it('should not update the doc in the API', function(done) {
+    return it('should not update the doc in the API', function (done) {
       return DocstoreClient.getDoc(
         this.project_id,
         this.doc_id,
@@ -100,8 +100,8 @@ describe('Applying updates to a doc', function() {
     })
   })
 
-  describe('when the lines have changed', function() {
-    beforeEach(function(done) {
+  describe('when the lines have changed', function () {
+    beforeEach(function (done) {
       return DocstoreClient.updateDoc(
         this.project_id,
         this.doc_id,
@@ -115,15 +115,15 @@ describe('Applying updates to a doc', function() {
       )
     })
 
-    it('should return modified = true', function() {
+    it('should return modified = true', function () {
       return this.body.modified.should.equal(true)
     })
 
-    it('should return the rev', function() {
+    it('should return the rev', function () {
       return this.body.rev.should.equal(2)
     })
 
-    return it('should update the doc in the API', function(done) {
+    return it('should update the doc in the API', function (done) {
       return DocstoreClient.getDoc(
         this.project_id,
         this.doc_id,
@@ -138,8 +138,8 @@ describe('Applying updates to a doc', function() {
     })
   })
 
-  describe('when the version has changed', function() {
-    beforeEach(function(done) {
+  describe('when the version has changed', function () {
+    beforeEach(function (done) {
       return DocstoreClient.updateDoc(
         this.project_id,
         this.doc_id,
@@ -153,15 +153,15 @@ describe('Applying updates to a doc', function() {
       )
     })
 
-    it('should return modified = true', function() {
+    it('should return modified = true', function () {
       return this.body.modified.should.equal(true)
     })
 
-    it('should return the rev', function() {
+    it('should return the rev', function () {
       return this.body.rev.should.equal(1)
     })
 
-    return it('should update the doc in the API', function(done) {
+    return it('should update the doc in the API', function (done) {
       return DocstoreClient.getDoc(
         this.project_id,
         this.doc_id,
@@ -176,8 +176,8 @@ describe('Applying updates to a doc', function() {
     })
   })
 
-  describe('when the ranges have changed', function() {
-    beforeEach(function(done) {
+  describe('when the ranges have changed', function () {
+    beforeEach(function (done) {
       return DocstoreClient.updateDoc(
         this.project_id,
         this.doc_id,
@@ -191,15 +191,15 @@ describe('Applying updates to a doc', function() {
       )
     })
 
-    it('should return modified = true', function() {
+    it('should return modified = true', function () {
       return this.body.modified.should.equal(true)
     })
 
-    it('should return the rev', function() {
+    it('should return the rev', function () {
       return this.body.rev.should.equal(2)
     })
 
-    return it('should update the doc in the API', function(done) {
+    return it('should update the doc in the API', function (done) {
       return DocstoreClient.getDoc(
         this.project_id,
         this.doc_id,
@@ -214,8 +214,8 @@ describe('Applying updates to a doc', function() {
     })
   })
 
-  describe('when the doc does not exist', function() {
-    beforeEach(function(done) {
+  describe('when the doc does not exist', function () {
+    beforeEach(function (done) {
       this.missing_doc_id = ObjectId()
       return DocstoreClient.updateDoc(
         this.project_id,
@@ -231,11 +231,11 @@ describe('Applying updates to a doc', function() {
       )
     })
 
-    it('should create the doc', function() {
+    it('should create the doc', function () {
       return this.body.rev.should.equal(1)
     })
 
-    return it('should be retreivable', function(done) {
+    return it('should be retreivable', function (done) {
       return DocstoreClient.getDoc(
         this.project_id,
         this.missing_doc_id,
@@ -250,9 +250,9 @@ describe('Applying updates to a doc', function() {
     })
   })
 
-  describe('when malformed doc lines are provided', function() {
-    describe('when the lines are not an array', function() {
-      beforeEach(function(done) {
+  describe('when malformed doc lines are provided', function () {
+    describe('when the lines are not an array', function () {
+      beforeEach(function (done) {
         return DocstoreClient.updateDoc(
           this.project_id,
           this.doc_id,
@@ -267,11 +267,11 @@ describe('Applying updates to a doc', function() {
         )
       })
 
-      it('should return 400', function() {
+      it('should return 400', function () {
         return this.res.statusCode.should.equal(400)
       })
 
-      return it('should not update the doc in the API', function(done) {
+      return it('should not update the doc in the API', function (done) {
         return DocstoreClient.getDoc(
           this.project_id,
           this.doc_id,
@@ -284,8 +284,8 @@ describe('Applying updates to a doc', function() {
       })
     })
 
-    return describe('when the lines are not present', function() {
-      beforeEach(function(done) {
+    return describe('when the lines are not present', function () {
+      beforeEach(function (done) {
         return DocstoreClient.updateDoc(
           this.project_id,
           this.doc_id,
@@ -300,11 +300,11 @@ describe('Applying updates to a doc', function() {
         )
       })
 
-      it('should return 400', function() {
+      it('should return 400', function () {
         return this.res.statusCode.should.equal(400)
       })
 
-      return it('should not update the doc in the API', function(done) {
+      return it('should not update the doc in the API', function (done) {
         return DocstoreClient.getDoc(
           this.project_id,
           this.doc_id,
@@ -318,8 +318,8 @@ describe('Applying updates to a doc', function() {
     })
   })
 
-  describe('when no version is provided', function() {
-    beforeEach(function(done) {
+  describe('when no version is provided', function () {
+    beforeEach(function (done) {
       return DocstoreClient.updateDoc(
         this.project_id,
         this.doc_id,
@@ -334,11 +334,11 @@ describe('Applying updates to a doc', function() {
       )
     })
 
-    it('should return 400', function() {
+    it('should return 400', function () {
       return this.res.statusCode.should.equal(400)
     })
 
-    return it('should not update the doc in the API', function(done) {
+    return it('should not update the doc in the API', function (done) {
       return DocstoreClient.getDoc(
         this.project_id,
         this.doc_id,
@@ -352,8 +352,8 @@ describe('Applying updates to a doc', function() {
     })
   })
 
-  describe('when the content is large', function() {
-    beforeEach(function(done) {
+  describe('when the content is large', function () {
+    beforeEach(function (done) {
       const line = new Array(1025).join('x') // 1kb
       this.largeLines = Array.apply(null, Array(1024)).map(() => line) // 1mb
       return DocstoreClient.updateDoc(
@@ -369,11 +369,11 @@ describe('Applying updates to a doc', function() {
       )
     })
 
-    it('should return modified = true', function() {
+    it('should return modified = true', function () {
       return this.body.modified.should.equal(true)
     })
 
-    return it('should update the doc in the API', function(done) {
+    return it('should update the doc in the API', function (done) {
       return DocstoreClient.getDoc(
         this.project_id,
         this.doc_id,
@@ -386,8 +386,8 @@ describe('Applying updates to a doc', function() {
     })
   })
 
-  describe('when there is a large json payload', function() {
-    beforeEach(function(done) {
+  describe('when there is a large json payload', function () {
+    beforeEach(function (done) {
       const line = new Array(1025).join('x') // 1kb
       this.largeLines = Array.apply(null, Array(1024)).map(() => line) // 1kb
       this.originalRanges.padding = Array.apply(null, Array(2049)).map(
@@ -407,11 +407,11 @@ describe('Applying updates to a doc', function() {
       )
     })
 
-    it('should return modified = true', function() {
+    it('should return modified = true', function () {
       return this.body.modified.should.equal(true)
     })
 
-    return it('should update the doc in the API', function(done) {
+    return it('should update the doc in the API', function (done) {
       return DocstoreClient.getDoc(
         this.project_id,
         this.doc_id,
@@ -424,8 +424,8 @@ describe('Applying updates to a doc', function() {
     })
   })
 
-  describe('when the document body is too large', function() {
-    beforeEach(function(done) {
+  describe('when the document body is too large', function () {
+    beforeEach(function (done) {
       const line = new Array(1025).join('x') // 1kb
       this.largeLines = Array.apply(null, Array(2049)).map(() => line) // 2mb + 1kb
       return DocstoreClient.updateDoc(
@@ -442,15 +442,15 @@ describe('Applying updates to a doc', function() {
       )
     })
 
-    it('should return 413', function() {
+    it('should return 413', function () {
       return this.res.statusCode.should.equal(413)
     })
 
-    it('should report body too large', function() {
+    it('should report body too large', function () {
       return this.res.body.should.equal('document body too large')
     })
 
-    return it('should not update the doc in the API', function(done) {
+    return it('should not update the doc in the API', function (done) {
       return DocstoreClient.getDoc(
         this.project_id,
         this.doc_id,
@@ -463,8 +463,8 @@ describe('Applying updates to a doc', function() {
     })
   })
 
-  return describe('when the json payload is too large', function() {
-    beforeEach(function(done) {
+  return describe('when the json payload is too large', function () {
+    beforeEach(function (done) {
       const line = new Array(1025).join('x') // 1kb
       this.largeLines = Array.apply(null, Array(1024)).map(() => line) // 1kb
       this.originalRanges.padding = Array.apply(null, Array(4096)).map(
@@ -484,7 +484,7 @@ describe('Applying updates to a doc', function() {
       )
     })
 
-    return it('should not update the doc in the API', function(done) {
+    return it('should not update the doc in the API', function (done) {
       return DocstoreClient.getDoc(
         this.project_id,
         this.doc_id,

--- a/test/acceptance/js/helpers/DocstoreApp.js
+++ b/test/acceptance/js/helpers/DocstoreApp.js
@@ -21,7 +21,7 @@ module.exports = {
   callbacks: [],
   ensureRunning(callback) {
     if (callback == null) {
-      callback = function(error) {}
+      callback = function (error) {}
     }
     if (this.running) {
       return callback()
@@ -30,19 +30,23 @@ module.exports = {
     } else {
       this.initing = true
       this.callbacks.push(callback)
-      return app.listen(settings.internal.docstore.port, 'localhost', error => {
-        if (error != null) {
-          throw error
-        }
-        this.running = true
-        return (() => {
-          const result = []
-          for (callback of Array.from(this.callbacks)) {
-            result.push(callback())
+      return app.listen(
+        settings.internal.docstore.port,
+        'localhost',
+        (error) => {
+          if (error != null) {
+            throw error
           }
-          return result
-        })()
-      })
+          this.running = true
+          return (() => {
+            const result = []
+            for (callback of Array.from(this.callbacks)) {
+              result.push(callback())
+            }
+            return result
+          })()
+        }
+      )
     }
   }
 }

--- a/test/acceptance/js/helpers/DocstoreClient.js
+++ b/test/acceptance/js/helpers/DocstoreClient.js
@@ -20,7 +20,7 @@ const DocArchiveManager = require('../../../../app/js/DocArchiveManager.js')
 module.exports = DocstoreClient = {
   createDoc(project_id, doc_id, lines, version, ranges, callback) {
     if (callback == null) {
-      callback = function(error) {}
+      callback = function (error) {}
     }
     return DocstoreClient.updateDoc(
       project_id,
@@ -34,7 +34,7 @@ module.exports = DocstoreClient = {
 
   getDoc(project_id, doc_id, qs, callback) {
     if (callback == null) {
-      callback = function(error, res, body) {}
+      callback = function (error, res, body) {}
     }
     return request.get(
       {
@@ -48,7 +48,7 @@ module.exports = DocstoreClient = {
 
   getAllDocs(project_id, callback) {
     if (callback == null) {
-      callback = function(error, res, body) {}
+      callback = function (error, res, body) {}
     }
     return request.get(
       {
@@ -61,7 +61,7 @@ module.exports = DocstoreClient = {
 
   getAllRanges(project_id, callback) {
     if (callback == null) {
-      callback = function(error, res, body) {}
+      callback = function (error, res, body) {}
     }
     return request.get(
       {
@@ -74,7 +74,7 @@ module.exports = DocstoreClient = {
 
   updateDoc(project_id, doc_id, lines, version, ranges, callback) {
     if (callback == null) {
-      callback = function(error, res, body) {}
+      callback = function (error, res, body) {}
     }
     return request.post(
       {
@@ -91,7 +91,7 @@ module.exports = DocstoreClient = {
 
   deleteDoc(project_id, doc_id, callback) {
     if (callback == null) {
-      callback = function(error, res, body) {}
+      callback = function (error, res, body) {}
     }
     return request.del(
       {
@@ -103,7 +103,7 @@ module.exports = DocstoreClient = {
 
   archiveAllDoc(project_id, callback) {
     if (callback == null) {
-      callback = function(error, res, body) {}
+      callback = function (error, res, body) {}
     }
     return request.post(
       {
@@ -115,7 +115,7 @@ module.exports = DocstoreClient = {
 
   destroyAllDoc(project_id, callback) {
     if (callback == null) {
-      callback = function(error, res, body) {}
+      callback = function (error, res, body) {}
     }
     return request.post(
       {
@@ -127,7 +127,7 @@ module.exports = DocstoreClient = {
 
   getS3Doc(project_id, doc_id, callback) {
     if (callback == null) {
-      callback = function(error, res, body) {}
+      callback = function (error, res, body) {}
     }
     const options = DocArchiveManager.buildS3Options(project_id + '/' + doc_id)
     options.json = true

--- a/test/unit/js/DocArchiveManagerTests.js
+++ b/test/unit/js/DocArchiveManagerTests.js
@@ -23,8 +23,8 @@ const { ObjectId } = require('mongojs')
 const Errors = require('../../../app/js/Errors')
 const crypto = require('crypto')
 
-describe('DocArchiveManager', function() {
-  beforeEach(function() {
+describe('DocArchiveManager', function () {
+  beforeEach(function () {
     this.settings = {
       docstore: {
         s3: {
@@ -135,15 +135,15 @@ describe('DocArchiveManager', function() {
     }))
   })
 
-  describe('archiveDoc', function() {
-    it('should use correct options', function(done) {
+  describe('archiveDoc', function () {
+    it('should use correct options', function (done) {
       this.request.put = sinon
         .stub()
         .callsArgWith(1, null, { statusCode: 200, headers: { etag: '' } })
       return this.DocArchiveManager.archiveDoc(
         this.project_id,
         this.mongoDocs[0],
-        err => {
+        (err) => {
           const opts = this.request.put.args[0][0]
           assert.deepEqual(opts.aws, {
             key: this.settings.docstore.s3.key,
@@ -166,30 +166,27 @@ describe('DocArchiveManager', function() {
       )
     })
 
-    it('should return no md5 error', function(done) {
+    it('should return no md5 error', function (done) {
       const data = JSON.stringify({
         lines: this.mongoDocs[0].lines,
         ranges: this.mongoDocs[0].ranges,
         schema_v: 1
       })
-      this.md5 = crypto
-        .createHash('md5')
-        .update(data)
-        .digest('hex')
+      this.md5 = crypto.createHash('md5').update(data).digest('hex')
       this.request.put = sinon
         .stub()
         .callsArgWith(1, null, { statusCode: 200, headers: { etag: this.md5 } })
       return this.DocArchiveManager.archiveDoc(
         this.project_id,
         this.mongoDocs[0],
-        err => {
+        (err) => {
           should.not.exist(err)
           return done()
         }
       )
     })
 
-    return it('should return the error', function(done) {
+    return it('should return the error', function (done) {
       this.request.put = sinon.stub().callsArgWith(1, this.stubbedError, {
         statusCode: 400,
         headers: { etag: '' }
@@ -197,7 +194,7 @@ describe('DocArchiveManager', function() {
       return this.DocArchiveManager.archiveDoc(
         this.project_id,
         this.mongoDocs[0],
-        err => {
+        (err) => {
           should.exist(err)
           return done()
         }
@@ -205,8 +202,8 @@ describe('DocArchiveManager', function() {
     })
   })
 
-  describe('unarchiveDoc', function() {
-    it('should use correct options', function(done) {
+  describe('unarchiveDoc', function () {
+    it('should use correct options', function (done) {
       this.request.get = sinon
         .stub()
         .callsArgWith(1, null, { statusCode: 200 }, this.mongoDocs[0].lines)
@@ -216,7 +213,7 @@ describe('DocArchiveManager', function() {
       return this.DocArchiveManager.unarchiveDoc(
         this.project_id,
         this.mongoDocs[0]._id,
-        err => {
+        (err) => {
           const opts = this.request.get.args[0][0]
           assert.deepEqual(opts.aws, {
             key: this.settings.docstore.s3.key,
@@ -233,19 +230,19 @@ describe('DocArchiveManager', function() {
       )
     })
 
-    it('should return the error', function(done) {
+    it('should return the error', function (done) {
       this.request.get = sinon.stub().callsArgWith(1, this.stubbedError, {}, {})
       return this.DocArchiveManager.unarchiveDoc(
         this.project_id,
         this.mongoDocs[0],
-        err => {
+        (err) => {
           should.exist(err)
           return done()
         }
       )
     })
 
-    return it('should error if the doc lines are a string not an array', function(done) {
+    return it('should error if the doc lines are a string not an array', function (done) {
       this.request.get = sinon
         .stub()
         .callsArgWith(1, null, { statusCode: 200 }, 'this is a string')
@@ -253,7 +250,7 @@ describe('DocArchiveManager', function() {
       return this.DocArchiveManager.unarchiveDoc(
         this.project_id,
         this.mongoDocs[0],
-        err => {
+        (err) => {
           should.exist(err)
           this.request.del.called.should.equal(false)
           return done()
@@ -262,14 +259,14 @@ describe('DocArchiveManager', function() {
     })
   })
 
-  describe('archiveAllDocs', function() {
-    it('should archive all project docs which are not in s3', function(done) {
+  describe('archiveAllDocs', function () {
+    it('should archive all project docs which are not in s3', function (done) {
       this.MongoManager.getProjectsDocs = sinon
         .stub()
         .callsArgWith(3, null, this.mongoDocs)
       this.DocArchiveManager.archiveDoc = sinon.stub().callsArgWith(2, null)
 
-      return this.DocArchiveManager.archiveAllDocs(this.project_id, err => {
+      return this.DocArchiveManager.archiveAllDocs(this.project_id, (err) => {
         this.DocArchiveManager.archiveDoc
           .calledWith(this.project_id, this.mongoDocs[0])
           .should.equal(true)
@@ -292,30 +289,30 @@ describe('DocArchiveManager', function() {
       })
     })
 
-    it('should return error if have no docs', function(done) {
+    it('should return error if have no docs', function (done) {
       this.MongoManager.getProjectsDocs = sinon
         .stub()
         .callsArgWith(3, null, null)
 
-      return this.DocArchiveManager.archiveAllDocs(this.project_id, err => {
+      return this.DocArchiveManager.archiveAllDocs(this.project_id, (err) => {
         should.exist(err)
         return done()
       })
     })
 
-    it('should return the error', function(done) {
+    it('should return the error', function (done) {
       this.MongoManager.getProjectsDocs = sinon
         .stub()
         .callsArgWith(3, this.error, null)
 
-      return this.DocArchiveManager.archiveAllDocs(this.project_id, err => {
+      return this.DocArchiveManager.archiveAllDocs(this.project_id, (err) => {
         err.should.equal(this.error)
         return done()
       })
     })
 
-    return describe('when most have been already put in s3', function() {
-      beforeEach(function() {
+    return describe('when most have been already put in s3', function () {
+      beforeEach(function () {
         let numberOfDocs = 10 * 1000
         this.mongoDocs = []
         while (--numberOfDocs !== 0) {
@@ -330,8 +327,8 @@ describe('DocArchiveManager', function() {
           .callsArgWith(2, null))
       })
 
-      return it('should not throw and error', function(done) {
-        return this.DocArchiveManager.archiveAllDocs(this.project_id, err => {
+      return it('should not throw and error', function (done) {
+        return this.DocArchiveManager.archiveAllDocs(this.project_id, (err) => {
           should.not.exist(err)
           return done()
         })
@@ -339,13 +336,13 @@ describe('DocArchiveManager', function() {
     })
   })
 
-  describe('unArchiveAllDocs', function() {
-    it('should unarchive all inS3 docs', function(done) {
+  describe('unArchiveAllDocs', function () {
+    it('should unarchive all inS3 docs', function (done) {
       this.MongoManager.getArchivedProjectDocs = sinon
         .stub()
         .callsArgWith(1, null, this.archivedDocs)
       this.DocArchiveManager.unarchiveDoc = sinon.stub().callsArgWith(2, null)
-      return this.DocArchiveManager.unArchiveAllDocs(this.project_id, err => {
+      return this.DocArchiveManager.unArchiveAllDocs(this.project_id, (err) => {
         for (const doc of Array.from(this.archivedDocs)) {
           this.DocArchiveManager.unarchiveDoc
             .calledWith(this.project_id, doc._id)
@@ -356,29 +353,29 @@ describe('DocArchiveManager', function() {
       })
     })
 
-    it('should return error if have no docs', function(done) {
+    it('should return error if have no docs', function (done) {
       this.MongoManager.getArchivedProjectDocs = sinon
         .stub()
         .callsArgWith(1, null, null)
-      return this.DocArchiveManager.unArchiveAllDocs(this.project_id, err => {
+      return this.DocArchiveManager.unArchiveAllDocs(this.project_id, (err) => {
         should.exist(err)
         return done()
       })
     })
 
-    return it('should return the error', function(done) {
+    return it('should return the error', function (done) {
       this.MongoManager.getArchivedProjectDocs = sinon
         .stub()
         .callsArgWith(1, this.error, null)
-      return this.DocArchiveManager.unArchiveAllDocs(this.project_id, err => {
+      return this.DocArchiveManager.unArchiveAllDocs(this.project_id, (err) => {
         err.should.equal(this.error)
         return done()
       })
     })
   })
 
-  describe('destroyAllDocs', function() {
-    beforeEach(function() {
+  describe('destroyAllDocs', function () {
+    beforeEach(function () {
       this.request.del = sinon
         .stub()
         .callsArgWith(1, null, { statusCode: 204 }, {})
@@ -387,16 +384,16 @@ describe('DocArchiveManager', function() {
         .callsArgWith(3, null, this.mixedDocs)
       this.MongoManager.findDoc = sinon.stub().callsArgWith(3, null, null)
       this.MongoManager.destroyDoc = sinon.stub().yields()
-      return Array.from(this.mixedDocs).map(doc =>
+      return Array.from(this.mixedDocs).map((doc) =>
         this.MongoManager.findDoc
           .withArgs(this.project_id, doc._id)
           .callsArgWith(3, null, doc)
       )
     })
 
-    it('should destroy all the docs', function(done) {
+    it('should destroy all the docs', function (done) {
       this.DocArchiveManager.destroyDoc = sinon.stub().callsArgWith(2, null)
-      return this.DocArchiveManager.destroyAllDocs(this.project_id, err => {
+      return this.DocArchiveManager.destroyAllDocs(this.project_id, (err) => {
         for (const doc of Array.from(this.mixedDocs)) {
           this.DocArchiveManager.destroyDoc
             .calledWith(this.project_id, doc._id)
@@ -407,8 +404,8 @@ describe('DocArchiveManager', function() {
       })
     })
 
-    it('should only the s3 docs from s3', function(done) {
-      const docOpts = doc => {
+    it('should only the s3 docs from s3', function (done) {
+      const docOpts = (doc) => {
         return JSON.parse(
           JSON.stringify({
             aws: {
@@ -423,7 +420,7 @@ describe('DocArchiveManager', function() {
         )
       }
 
-      return this.DocArchiveManager.destroyAllDocs(this.project_id, err => {
+      return this.DocArchiveManager.destroyAllDocs(this.project_id, (err) => {
         let doc
         expect(err).not.to.exist
 
@@ -438,8 +435,8 @@ describe('DocArchiveManager', function() {
       })
     })
 
-    return it('should remove the docs from mongo', function(done) {
-      this.DocArchiveManager.destroyAllDocs(this.project_id, err => {
+    return it('should remove the docs from mongo', function (done) {
+      this.DocArchiveManager.destroyAllDocs(this.project_id, (err) => {
         return expect(err).not.to.exist
       })
 
@@ -451,9 +448,9 @@ describe('DocArchiveManager', function() {
     })
   })
 
-  describe('_s3DocToMongoDoc', function() {
-    describe('with the old schema', function() {
-      return it('should return the docs lines', function(done) {
+  describe('_s3DocToMongoDoc', function () {
+    describe('with the old schema', function () {
+      return it('should return the docs lines', function (done) {
         return this.DocArchiveManager._s3DocToMongoDoc(
           ['doc', 'lines'],
           (error, doc) => {
@@ -466,8 +463,8 @@ describe('DocArchiveManager', function() {
       })
     })
 
-    describe('with the new schema', function() {
-      it('should return the doc lines and ranges', function(done) {
+    describe('with the new schema', function () {
+      it('should return the doc lines and ranges', function (done) {
         this.RangeManager.jsonRangesToMongo = sinon
           .stub()
           .returns({ mongo: 'ranges' })
@@ -487,7 +484,7 @@ describe('DocArchiveManager', function() {
         )
       })
 
-      return it('should return just the doc lines when there are no ranges', function(done) {
+      return it('should return just the doc lines when there are no ranges', function (done) {
         return this.DocArchiveManager._s3DocToMongoDoc(
           {
             lines: ['doc', 'lines'],
@@ -503,8 +500,8 @@ describe('DocArchiveManager', function() {
       })
     })
 
-    return describe('with an unrecognised schema', function() {
-      return it('should return an error', function(done) {
+    return describe('with an unrecognised schema', function () {
+      return it('should return an error', function (done) {
         return this.DocArchiveManager._s3DocToMongoDoc(
           {
             schema_v: 2
@@ -518,9 +515,9 @@ describe('DocArchiveManager', function() {
     })
   })
 
-  return describe('_mongoDocToS3Doc', function() {
-    describe('with a valid doc', function() {
-      return it('should return the json version', function(done) {
+  return describe('_mongoDocToS3Doc', function () {
+    describe('with a valid doc', function () {
+      return it('should return the json version', function (done) {
         let doc
         return this.DocArchiveManager._mongoDocToS3Doc(
           (doc = {
@@ -541,17 +538,17 @@ describe('DocArchiveManager', function() {
       })
     })
 
-    describe('with null bytes in the result', function() {
-      beforeEach(function() {
+    describe('with null bytes in the result', function () {
+      beforeEach(function () {
         this._stringify = JSON.stringify
         return (JSON.stringify = sinon.stub().returns('{"bad": "\u0000"}'))
       })
 
-      afterEach(function() {
+      afterEach(function () {
         return (JSON.stringify = this._stringify)
       })
 
-      return it('should return an error', function(done) {
+      return it('should return an error', function (done) {
         return this.DocArchiveManager._mongoDocToS3Doc(
           {
             lines: ['doc', 'lines'],
@@ -565,8 +562,8 @@ describe('DocArchiveManager', function() {
       })
     })
 
-    return describe('without doc lines', function() {
-      return it('should return an error', function(done) {
+    return describe('without doc lines', function () {
+      return it('should return an error', function (done) {
         return this.DocArchiveManager._mongoDocToS3Doc({}, (err, s3_doc) => {
           expect(err).to.exist
           return done()

--- a/test/unit/js/DocManagerTests.js
+++ b/test/unit/js/DocManagerTests.js
@@ -22,8 +22,8 @@ const modulePath = require('path').join(__dirname, '../../../app/js/DocManager')
 const { ObjectId } = require('mongojs')
 const Errors = require('../../../app/js/Errors')
 
-describe('DocManager', function() {
-  beforeEach(function() {
+describe('DocManager', function () {
+  beforeEach(function () {
     this.DocManager = SandboxedModule.require(modulePath, {
       requires: {
         './MongoManager': (this.MongoManager = {}),
@@ -48,12 +48,12 @@ describe('DocManager', function() {
     return (this.stubbedError = new Error('blew up'))
   })
 
-  describe('checkDocExists', function() {
-    beforeEach(function() {
+  describe('checkDocExists', function () {
+    beforeEach(function () {
       return (this.DocManager._getDoc = sinon.stub())
     })
 
-    it('should call get doc with a quick filter', function(done) {
+    it('should call get doc with a quick filter', function (done) {
       this.DocManager._getDoc.callsArgWith(3, null, { _id: this.doc_id })
       return this.DocManager.checkDocExists(
         this.project_id,
@@ -68,7 +68,7 @@ describe('DocManager', function() {
       )
     })
 
-    it('should return false when doc is not there', function(done) {
+    it('should return false when doc is not there', function (done) {
       this.DocManager._getDoc.callsArgWith(3, null)
       return this.DocManager.checkDocExists(
         this.project_id,
@@ -80,7 +80,7 @@ describe('DocManager', function() {
       )
     })
 
-    return it('should return error when get doc errors', function(done) {
+    return it('should return error when get doc errors', function (done) {
       this.DocManager._getDoc.callsArgWith(3, 'error')
       return this.DocManager.checkDocExists(
         this.project_id,
@@ -93,8 +93,8 @@ describe('DocManager', function() {
     })
   })
 
-  describe('getFullDoc', function() {
-    beforeEach(function() {
+  describe('getFullDoc', function () {
+    beforeEach(function () {
       this.DocManager._getDoc = sinon.stub()
       return (this.doc = {
         _id: this.doc_id,
@@ -102,7 +102,7 @@ describe('DocManager', function() {
       })
     })
 
-    it('should call get doc with a quick filter', function(done) {
+    it('should call get doc with a quick filter', function (done) {
       this.DocManager._getDoc.callsArgWith(3, null, this.doc)
       return this.DocManager.getFullDoc(
         this.project_id,
@@ -124,7 +124,7 @@ describe('DocManager', function() {
       )
     })
 
-    return it('should return error when get doc errors', function(done) {
+    return it('should return error when get doc errors', function (done) {
       this.DocManager._getDoc.callsArgWith(3, 'error')
       return this.DocManager.getFullDoc(
         this.project_id,
@@ -137,13 +137,13 @@ describe('DocManager', function() {
     })
   })
 
-  describe('getRawDoc', function() {
-    beforeEach(function() {
+  describe('getRawDoc', function () {
+    beforeEach(function () {
       this.DocManager._getDoc = sinon.stub()
       return (this.doc = { lines: ['2134'] })
     })
 
-    it('should call get doc with a quick filter', function(done) {
+    it('should call get doc with a quick filter', function (done) {
       this.DocManager._getDoc.callsArgWith(3, null, this.doc)
       return this.DocManager.getDocLines(
         this.project_id,
@@ -161,7 +161,7 @@ describe('DocManager', function() {
       )
     })
 
-    return it('should return error when get doc errors', function(done) {
+    return it('should return error when get doc errors', function (done) {
       this.DocManager._getDoc.callsArgWith(3, 'error')
       return this.DocManager.getDocLines(
         this.project_id,
@@ -174,8 +174,8 @@ describe('DocManager', function() {
     })
   })
 
-  describe('getDoc', function() {
-    beforeEach(function() {
+  describe('getDoc', function () {
+    beforeEach(function () {
       this.project = { name: 'mock-project' }
       this.doc = {
         _id: this.doc_id,
@@ -189,29 +189,29 @@ describe('DocManager', function() {
         .yields(null, this.version))
     })
 
-    describe('when using a filter', function() {
-      beforeEach(function() {
+    describe('when using a filter', function () {
+      beforeEach(function () {
         return this.MongoManager.findDoc.yields(null, this.doc)
       })
 
-      it('should error if inS3 is not set to true', function(done) {
+      it('should error if inS3 is not set to true', function (done) {
         return this.DocManager._getDoc(
           this.project_id,
           this.doc_id,
           { inS3: false },
-          err => {
+          (err) => {
             expect(err).to.exist
             return done()
           }
         )
       })
 
-      it('should always get inS3 even when no filter is passed', function(done) {
+      it('should always get inS3 even when no filter is passed', function (done) {
         return this.DocManager._getDoc(
           this.project_id,
           this.doc_id,
           undefined,
-          err => {
+          (err) => {
             this.MongoManager.findDoc.called.should.equal(false)
             expect(err).to.exist
             return done()
@@ -219,12 +219,12 @@ describe('DocManager', function() {
         )
       })
 
-      return it('should not error if inS3 is set to true', function(done) {
+      return it('should not error if inS3 is set to true', function (done) {
         return this.DocManager._getDoc(
           this.project_id,
           this.doc_id,
           { inS3: true },
-          err => {
+          (err) => {
             expect(err).to.not.exist
             return done()
           }
@@ -232,8 +232,8 @@ describe('DocManager', function() {
       })
     })
 
-    describe('when the doc is in the doc collection', function() {
-      beforeEach(function() {
+    describe('when the doc is in the doc collection', function () {
+      beforeEach(function () {
         this.MongoManager.findDoc.yields(null, this.doc)
         return this.DocManager._getDoc(
           this.project_id,
@@ -243,19 +243,19 @@ describe('DocManager', function() {
         )
       })
 
-      it('should get the doc from the doc collection', function() {
+      it('should get the doc from the doc collection', function () {
         return this.MongoManager.findDoc
           .calledWith(this.project_id, this.doc_id)
           .should.equal(true)
       })
 
-      it('should get the doc version from the docOps collection', function() {
+      it('should get the doc version from the docOps collection', function () {
         return this.MongoManager.getDocVersion
           .calledWith(this.doc_id)
           .should.equal(true)
       })
 
-      return it('should return the callback with the doc with the version', function() {
+      return it('should return the callback with the doc with the version', function () {
         this.callback.called.should.equal(true)
         const doc = this.callback.args[0][1]
         doc.lines.should.equal(this.doc.lines)
@@ -263,8 +263,8 @@ describe('DocManager', function() {
       })
     })
 
-    describe('without the version filter', function() {
-      beforeEach(function() {
+    describe('without the version filter', function () {
+      beforeEach(function () {
         this.MongoManager.findDoc.yields(null, this.doc)
         return this.DocManager._getDoc(
           this.project_id,
@@ -274,13 +274,13 @@ describe('DocManager', function() {
         )
       })
 
-      return it('should not get the doc version from the docOps collection', function() {
+      return it('should not get the doc version from the docOps collection', function () {
         return this.MongoManager.getDocVersion.called.should.equal(false)
       })
     })
 
-    describe('when MongoManager.findDoc errors', function() {
-      beforeEach(function() {
+    describe('when MongoManager.findDoc errors', function () {
+      beforeEach(function () {
         this.MongoManager.findDoc.yields(this.stubbedError)
         return this.DocManager._getDoc(
           this.project_id,
@@ -290,13 +290,13 @@ describe('DocManager', function() {
         )
       })
 
-      return it('should return the error', function() {
+      return it('should return the error', function () {
         return this.callback.calledWith(this.stubbedError).should.equal(true)
       })
     })
 
-    describe('when the doc is archived', function() {
-      beforeEach(function() {
+    describe('when the doc is archived', function () {
+      beforeEach(function () {
         this.doc = {
           _id: this.doc_id,
           project_id: this.project_id,
@@ -321,23 +321,23 @@ describe('DocManager', function() {
         )
       })
 
-      it('should call the DocArchive to unarchive the doc', function() {
+      it('should call the DocArchive to unarchive the doc', function () {
         return this.DocArchiveManager.unarchiveDoc
           .calledWith(this.project_id, this.doc_id)
           .should.equal(true)
       })
 
-      it('should look up the doc twice', function() {
+      it('should look up the doc twice', function () {
         return this.MongoManager.findDoc.calledTwice.should.equal(true)
       })
 
-      return it('should return the doc', function() {
+      return it('should return the doc', function () {
         return this.callback.calledWith(null, this.doc).should.equal(true)
       })
     })
 
-    return describe('when the doc does not exist in the docs collection', function() {
-      beforeEach(function() {
+    return describe('when the doc does not exist in the docs collection', function () {
+      beforeEach(function () {
         this.MongoManager.findDoc = sinon.stub().yields(null, null)
         return this.DocManager._getDoc(
           this.project_id,
@@ -347,7 +347,7 @@ describe('DocManager', function() {
         )
       })
 
-      return it('should return a NotFoundError', function() {
+      return it('should return a NotFoundError', function () {
         return this.callback
           .calledWith(
             sinon.match.has(
@@ -360,9 +360,9 @@ describe('DocManager', function() {
     })
   })
 
-  describe('getAllNonDeletedDocs', function() {
-    describe('when the project exists', function() {
-      beforeEach(function() {
+  describe('getAllNonDeletedDocs', function () {
+    describe('when the project exists', function () {
+      beforeEach(function () {
         this.docs = [
           {
             _id: this.doc_id,
@@ -384,19 +384,19 @@ describe('DocManager', function() {
         )
       })
 
-      it('should get the project from the database', function() {
+      it('should get the project from the database', function () {
         return this.MongoManager.getProjectsDocs
           .calledWith(this.project_id, { include_deleted: false }, this.filter)
           .should.equal(true)
       })
 
-      return it('should return the docs', function() {
+      return it('should return the docs', function () {
         return this.callback.calledWith(null, this.docs).should.equal(true)
       })
     })
 
-    return describe('when there are no docs for the project', function() {
-      beforeEach(function() {
+    return describe('when there are no docs for the project', function () {
+      beforeEach(function () {
         this.MongoManager.getProjectsDocs = sinon
           .stub()
           .callsArgWith(3, null, null)
@@ -410,7 +410,7 @@ describe('DocManager', function() {
         )
       })
 
-      return it('should return a NotFoundError', function() {
+      return it('should return a NotFoundError', function () {
         return this.callback
           .calledWith(
             sinon.match.has('message', `No docs for project ${this.project_id}`)
@@ -420,9 +420,9 @@ describe('DocManager', function() {
     })
   })
 
-  describe('deleteDoc', function() {
-    describe('when the doc exists', function() {
-      beforeEach(function() {
+  describe('deleteDoc', function () {
+    describe('when the doc exists', function () {
+      beforeEach(function () {
         this.lines = ['mock', 'doc', 'lines']
         this.rev = 77
         this.DocManager.checkDocExists = sinon
@@ -436,25 +436,25 @@ describe('DocManager', function() {
         )
       })
 
-      it('should get the doc', function() {
+      it('should get the doc', function () {
         return this.DocManager.checkDocExists
           .calledWith(this.project_id, this.doc_id)
           .should.equal(true)
       })
 
-      it('should mark doc as deleted', function() {
+      it('should mark doc as deleted', function () {
         return this.MongoManager.markDocAsDeleted
           .calledWith(this.project_id, this.doc_id)
           .should.equal(true)
       })
 
-      return it('should return the callback', function() {
+      return it('should return the callback', function () {
         return this.callback.called.should.equal(true)
       })
     })
 
-    return describe('when the doc does not exist', function() {
-      beforeEach(function() {
+    return describe('when the doc does not exist', function () {
+      beforeEach(function () {
         this.DocManager.checkDocExists = sinon
           .stub()
           .callsArgWith(2, null, false)
@@ -465,7 +465,7 @@ describe('DocManager', function() {
         )
       })
 
-      return it('should return a NotFoundError', function() {
+      return it('should return a NotFoundError', function () {
         return this.callback
           .calledWith(
             sinon.match.has(
@@ -478,8 +478,8 @@ describe('DocManager', function() {
     })
   })
 
-  return describe('updateDoc', function() {
-    beforeEach(function() {
+  return describe('updateDoc', function () {
+    beforeEach(function () {
       this.oldDocLines = ['old', 'doc', 'lines']
       this.newDocLines = ['new', 'doc', 'lines']
       this.originalRanges = {
@@ -521,8 +521,8 @@ describe('DocManager', function() {
       return (this.DocManager._getDoc = sinon.stub())
     })
 
-    describe('when only the doc lines have changed', function() {
-      beforeEach(function() {
+    describe('when only the doc lines have changed', function () {
+      beforeEach(function () {
         this.DocManager._getDoc = sinon.stub().callsArgWith(3, null, this.doc)
         return this.DocManager.updateDoc(
           this.project_id,
@@ -534,7 +534,7 @@ describe('DocManager', function() {
         )
       })
 
-      it('should get the existing doc', function() {
+      it('should get the existing doc', function () {
         return this.DocManager._getDoc
           .calledWith(this.project_id, this.doc_id, {
             version: true,
@@ -547,25 +547,25 @@ describe('DocManager', function() {
           .should.equal(true)
       })
 
-      it('should upsert the document to the doc collection', function() {
+      it('should upsert the document to the doc collection', function () {
         return this.MongoManager.upsertIntoDocCollection
           .calledWith(this.project_id, this.doc_id, { lines: this.newDocLines })
           .should.equal(true)
       })
 
-      it('should not update the version', function() {
+      it('should not update the version', function () {
         return this.MongoManager.setDocVersion.called.should.equal(false)
       })
 
-      return it('should return the callback with the new rev', function() {
+      return it('should return the callback with the new rev', function () {
         return this.callback
           .calledWith(null, true, this.rev + 1)
           .should.equal(true)
       })
     })
 
-    describe('when the doc ranges have changed', function() {
-      beforeEach(function() {
+    describe('when the doc ranges have changed', function () {
+      beforeEach(function () {
         this.DocManager._getDoc = sinon.stub().callsArgWith(3, null, this.doc)
         this.RangeManager.shouldUpdateRanges.returns(true)
         return this.DocManager.updateDoc(
@@ -578,25 +578,25 @@ describe('DocManager', function() {
         )
       })
 
-      it('should upsert the ranges', function() {
+      it('should upsert the ranges', function () {
         return this.MongoManager.upsertIntoDocCollection
           .calledWith(this.project_id, this.doc_id, { ranges: this.newRanges })
           .should.equal(true)
       })
 
-      it('should not update the version', function() {
+      it('should not update the version', function () {
         return this.MongoManager.setDocVersion.called.should.equal(false)
       })
 
-      return it('should return the callback with the new rev', function() {
+      return it('should return the callback with the new rev', function () {
         return this.callback
           .calledWith(null, true, this.rev + 1)
           .should.equal(true)
       })
     })
 
-    describe('when only the version has changed', function() {
-      beforeEach(function() {
+    describe('when only the version has changed', function () {
+      beforeEach(function () {
         this.DocManager._getDoc = sinon.stub().callsArgWith(3, null, this.doc)
         return this.DocManager.updateDoc(
           this.project_id,
@@ -608,25 +608,25 @@ describe('DocManager', function() {
         )
       })
 
-      it('should not change the lines or ranges', function() {
+      it('should not change the lines or ranges', function () {
         return this.MongoManager.upsertIntoDocCollection.called.should.equal(
           false
         )
       })
 
-      it('should update the version', function() {
+      it('should update the version', function () {
         return this.MongoManager.setDocVersion
           .calledWith(this.doc_id, this.version + 1)
           .should.equal(true)
       })
 
-      return it('should return the callback with the old rev', function() {
+      return it('should return the callback with the old rev', function () {
         return this.callback.calledWith(null, true, this.rev).should.equal(true)
       })
     })
 
-    describe('when the doc has not changed at all', function() {
-      beforeEach(function() {
+    describe('when the doc has not changed at all', function () {
+      beforeEach(function () {
         this.DocManager._getDoc = sinon.stub().callsArgWith(3, null, this.doc)
         return this.DocManager.updateDoc(
           this.project_id,
@@ -638,25 +638,25 @@ describe('DocManager', function() {
         )
       })
 
-      it('should not update the ranges or lines', function() {
+      it('should not update the ranges or lines', function () {
         return this.MongoManager.upsertIntoDocCollection.called.should.equal(
           false
         )
       })
 
-      it('should not update the version', function() {
+      it('should not update the version', function () {
         return this.MongoManager.setDocVersion.called.should.equal(false)
       })
 
-      return it('should return the callback with the old rev and modified == false', function() {
+      return it('should return the callback with the old rev and modified == false', function () {
         return this.callback
           .calledWith(null, false, this.rev)
           .should.equal(true)
       })
     })
 
-    describe('when the version is null', function() {
-      beforeEach(function() {
+    describe('when the version is null', function () {
+      beforeEach(function () {
         return this.DocManager.updateDoc(
           this.project_id,
           this.doc_id,
@@ -667,7 +667,7 @@ describe('DocManager', function() {
         )
       })
 
-      return it('should return an error', function() {
+      return it('should return an error', function () {
         return this.callback
           .calledWith(
             sinon.match.has('message', 'no lines, version or ranges provided')
@@ -676,8 +676,8 @@ describe('DocManager', function() {
       })
     })
 
-    describe('when the lines are null', function() {
-      beforeEach(function() {
+    describe('when the lines are null', function () {
+      beforeEach(function () {
         return this.DocManager.updateDoc(
           this.project_id,
           this.doc_id,
@@ -688,7 +688,7 @@ describe('DocManager', function() {
         )
       })
 
-      return it('should return an error', function() {
+      return it('should return an error', function () {
         return this.callback
           .calledWith(
             sinon.match.has('message', 'no lines, version or ranges provided')
@@ -697,8 +697,8 @@ describe('DocManager', function() {
       })
     })
 
-    describe('when the ranges are null', function() {
-      beforeEach(function() {
+    describe('when the ranges are null', function () {
+      beforeEach(function () {
         return this.DocManager.updateDoc(
           this.project_id,
           this.doc_id,
@@ -709,7 +709,7 @@ describe('DocManager', function() {
         )
       })
 
-      return it('should return an error', function() {
+      return it('should return an error', function () {
         return this.callback
           .calledWith(
             sinon.match.has('message', 'no lines, version or ranges provided')
@@ -718,8 +718,8 @@ describe('DocManager', function() {
       })
     })
 
-    describe('when there is a generic error getting the doc', function() {
-      beforeEach(function() {
+    describe('when there is a generic error getting the doc', function () {
+      beforeEach(function () {
         this.error = new Error('doc could not be found')
         this.DocManager._getDoc = sinon
           .stub()
@@ -734,19 +734,19 @@ describe('DocManager', function() {
         )
       })
 
-      it('should not upsert the document to the doc collection', function() {
+      it('should not upsert the document to the doc collection', function () {
         return this.MongoManager.upsertIntoDocCollection.called.should.equal(
           false
         )
       })
 
-      return it('should return the callback with the error', function() {
+      return it('should return the callback with the error', function () {
         return this.callback.calledWith(this.error).should.equal(true)
       })
     })
 
-    describe('when the doc lines have not changed', function() {
-      beforeEach(function() {
+    describe('when the doc lines have not changed', function () {
+      beforeEach(function () {
         this.DocManager._getDoc = sinon.stub().callsArgWith(3, null, this.doc)
         return this.DocManager.updateDoc(
           this.project_id,
@@ -758,21 +758,21 @@ describe('DocManager', function() {
         )
       })
 
-      it('should not update the doc', function() {
+      it('should not update the doc', function () {
         return this.MongoManager.upsertIntoDocCollection.called.should.equal(
           false
         )
       })
 
-      return it('should return the callback with the existing rev', function() {
+      return it('should return the callback with the existing rev', function () {
         return this.callback
           .calledWith(null, false, this.rev)
           .should.equal(true)
       })
     })
 
-    return describe('when the doc does not exist', function() {
-      beforeEach(function() {
+    return describe('when the doc does not exist', function () {
+      beforeEach(function () {
         this.DocManager._getDoc = sinon.stub().callsArgWith(3, null, null, null)
         return this.DocManager.updateDoc(
           this.project_id,
@@ -784,7 +784,7 @@ describe('DocManager', function() {
         )
       })
 
-      it('should upsert the document to the doc collection', function() {
+      it('should upsert the document to the doc collection', function () {
         return this.MongoManager.upsertIntoDocCollection
           .calledWith(this.project_id, this.doc_id, {
             lines: this.newDocLines,
@@ -793,13 +793,13 @@ describe('DocManager', function() {
           .should.equal(true)
       })
 
-      it('should set the version', function() {
+      it('should set the version', function () {
         return this.MongoManager.setDocVersion
           .calledWith(this.doc_id, this.version)
           .should.equal(true)
       })
 
-      return it('should return the callback with the new rev', function() {
+      return it('should return the callback with the new rev', function () {
         return this.callback.calledWith(null, true, 1).should.equal(true)
       })
     })

--- a/test/unit/js/HttpControllerTests.js
+++ b/test/unit/js/HttpControllerTests.js
@@ -21,8 +21,8 @@ const modulePath = require('path').join(
 )
 const { ObjectId } = require('mongojs')
 
-describe('HttpController', function() {
-  beforeEach(function() {
+describe('HttpController', function () {
+  beforeEach(function () {
     this.HttpController = SandboxedModule.require(modulePath, {
       requires: {
         './DocManager': (this.DocManager = {}),
@@ -60,9 +60,9 @@ describe('HttpController', function() {
     })
   })
 
-  describe('getDoc', function() {
-    describe('without deleted docs', function() {
-      beforeEach(function() {
+  describe('getDoc', function () {
+    describe('without deleted docs', function () {
+      beforeEach(function () {
         this.req.params = {
           project_id: this.project_id,
           doc_id: this.doc_id
@@ -73,13 +73,13 @@ describe('HttpController', function() {
         return this.HttpController.getDoc(this.req, this.res, this.next)
       })
 
-      it('should get the document with the version (including deleted)', function() {
+      it('should get the document with the version (including deleted)', function () {
         return this.DocManager.getFullDoc
           .calledWith(this.project_id, this.doc_id)
           .should.equal(true)
       })
 
-      return it('should return the doc as JSON', function() {
+      return it('should return the doc as JSON', function () {
         return this.res.json
           .calledWith({
             _id: this.doc_id,
@@ -91,8 +91,8 @@ describe('HttpController', function() {
       })
     })
 
-    return describe('which is deleted', function() {
-      beforeEach(function() {
+    return describe('which is deleted', function () {
+      beforeEach(function () {
         this.req.params = {
           project_id: this.project_id,
           doc_id: this.doc_id
@@ -102,19 +102,19 @@ describe('HttpController', function() {
           .callsArgWith(2, null, this.deletedDoc))
       })
 
-      it('should get the doc from the doc manager', function() {
+      it('should get the doc from the doc manager', function () {
         this.HttpController.getDoc(this.req, this.res, this.next)
         return this.DocManager.getFullDoc
           .calledWith(this.project_id, this.doc_id)
           .should.equal(true)
       })
 
-      it('should return 404 if the query string delete is not set ', function() {
+      it('should return 404 if the query string delete is not set ', function () {
         this.HttpController.getDoc(this.req, this.res, this.next)
         return this.res.send.calledWith(404).should.equal(true)
       })
 
-      return it('should return the doc as JSON if include_deleted is set to true', function() {
+      return it('should return the doc as JSON if include_deleted is set to true', function () {
         this.req.query.include_deleted = 'true'
         this.HttpController.getDoc(this.req, this.res, this.next)
         return this.res.json
@@ -130,8 +130,8 @@ describe('HttpController', function() {
     })
   })
 
-  describe('getRawDoc', function() {
-    beforeEach(function() {
+  describe('getRawDoc', function () {
+    beforeEach(function () {
       this.req.params = {
         project_id: this.project_id,
         doc_id: this.doc_id
@@ -140,19 +140,19 @@ describe('HttpController', function() {
       return this.HttpController.getRawDoc(this.req, this.res, this.next)
     })
 
-    it('should get the document without the version', function() {
+    it('should get the document without the version', function () {
       return this.DocManager.getDocLines
         .calledWith(this.project_id, this.doc_id)
         .should.equal(true)
     })
 
-    it('should set the content type header', function() {
+    it('should set the content type header', function () {
       return this.res.setHeader
         .calledWith('content-type', 'text/plain')
         .should.equal(true)
     })
 
-    return it('should send the raw version of the doc', function() {
+    return it('should send the raw version of the doc', function () {
       return assert.deepEqual(
         this.res.send.args[0][0],
         `${this.doc.lines[0]}\n${this.doc.lines[1]}\n${this.doc.lines[2]}\n${this.doc.lines[3]}\n${this.doc.lines[4]}\n${this.doc.lines[5]}`
@@ -160,9 +160,9 @@ describe('HttpController', function() {
     })
   })
 
-  describe('getAllDocs', function() {
-    describe('normally', function() {
-      beforeEach(function() {
+  describe('getAllDocs', function () {
+    describe('normally', function () {
+      beforeEach(function () {
         this.req.params = { project_id: this.project_id }
         this.docs = [
           {
@@ -182,13 +182,13 @@ describe('HttpController', function() {
         return this.HttpController.getAllDocs(this.req, this.res, this.next)
       })
 
-      it('should get all the (non-deleted) docs', function() {
+      it('should get all the (non-deleted) docs', function () {
         return this.DocManager.getAllNonDeletedDocs
           .calledWith(this.project_id, { lines: true, rev: true })
           .should.equal(true)
       })
 
-      return it('should return the doc as JSON', function() {
+      return it('should return the doc as JSON', function () {
         return this.res.json
           .calledWith([
             {
@@ -206,8 +206,8 @@ describe('HttpController', function() {
       })
     })
 
-    return describe('with a null doc', function() {
-      beforeEach(function() {
+    return describe('with a null doc', function () {
+      beforeEach(function () {
         this.req.params = { project_id: this.project_id }
         this.docs = [
           {
@@ -228,7 +228,7 @@ describe('HttpController', function() {
         return this.HttpController.getAllDocs(this.req, this.res, this.next)
       })
 
-      it('should return the non null docs as JSON', function() {
+      it('should return the non null docs as JSON', function () {
         return this.res.json
           .calledWith([
             {
@@ -245,7 +245,7 @@ describe('HttpController', function() {
           .should.equal(true)
       })
 
-      return it('should log out an error', function() {
+      return it('should log out an error', function () {
         return this.logger.error
           .calledWith(
             {
@@ -259,9 +259,9 @@ describe('HttpController', function() {
     })
   })
 
-  describe('getAllRanges', function() {
-    return describe('normally', function() {
-      beforeEach(function() {
+  describe('getAllRanges', function () {
+    return describe('normally', function () {
+      beforeEach(function () {
         this.req.params = { project_id: this.project_id }
         this.docs = [
           {
@@ -279,13 +279,13 @@ describe('HttpController', function() {
         return this.HttpController.getAllRanges(this.req, this.res, this.next)
       })
 
-      it('should get all the (non-deleted) doc ranges', function() {
+      it('should get all the (non-deleted) doc ranges', function () {
         return this.DocManager.getAllNonDeletedDocs
           .calledWith(this.project_id, { ranges: true })
           .should.equal(true)
       })
 
-      return it('should return the doc as JSON', function() {
+      return it('should return the doc as JSON', function () {
         return this.res.json
           .calledWith([
             {
@@ -302,16 +302,16 @@ describe('HttpController', function() {
     })
   })
 
-  describe('updateDoc', function() {
-    beforeEach(function() {
+  describe('updateDoc', function () {
+    beforeEach(function () {
       return (this.req.params = {
         project_id: this.project_id,
         doc_id: this.doc_id
       })
     })
 
-    describe('when the doc lines exist and were updated', function() {
-      beforeEach(function() {
+    describe('when the doc lines exist and were updated', function () {
+      beforeEach(function () {
         this.req.body = {
           lines: (this.lines = ['hello', 'world']),
           version: (this.version = 42),
@@ -323,7 +323,7 @@ describe('HttpController', function() {
         return this.HttpController.updateDoc(this.req, this.res, this.next)
       })
 
-      it('should update the document', function() {
+      it('should update the document', function () {
         return this.DocManager.updateDoc
           .calledWith(
             this.project_id,
@@ -335,15 +335,15 @@ describe('HttpController', function() {
           .should.equal(true)
       })
 
-      return it('should return a modified status', function() {
+      return it('should return a modified status', function () {
         return this.res.json
           .calledWith({ modified: true, rev: this.rev })
           .should.equal(true)
       })
     })
 
-    describe('when the doc lines exist and were not updated', function() {
-      beforeEach(function() {
+    describe('when the doc lines exist and were not updated', function () {
+      beforeEach(function () {
         this.req.body = {
           lines: (this.lines = ['hello', 'world']),
           version: (this.version = 42),
@@ -355,63 +355,63 @@ describe('HttpController', function() {
         return this.HttpController.updateDoc(this.req, this.res, this.next)
       })
 
-      return it('should return a modified status', function() {
+      return it('should return a modified status', function () {
         return this.res.json
           .calledWith({ modified: false, rev: this.rev })
           .should.equal(true)
       })
     })
 
-    describe('when the doc lines are not provided', function() {
-      beforeEach(function() {
+    describe('when the doc lines are not provided', function () {
+      beforeEach(function () {
         this.req.body = { version: 42, ranges: {} }
         this.DocManager.updateDoc = sinon.stub().yields(null, false)
         return this.HttpController.updateDoc(this.req, this.res, this.next)
       })
 
-      it('should not update the document', function() {
+      it('should not update the document', function () {
         return this.DocManager.updateDoc.called.should.equal(false)
       })
 
-      return it('should return a 400 (bad request) response', function() {
+      return it('should return a 400 (bad request) response', function () {
         return this.res.send.calledWith(400).should.equal(true)
       })
     })
 
-    describe('when the doc version are not provided', function() {
-      beforeEach(function() {
+    describe('when the doc version are not provided', function () {
+      beforeEach(function () {
         this.req.body = { version: 42, lines: ['hello world'] }
         this.DocManager.updateDoc = sinon.stub().yields(null, false)
         return this.HttpController.updateDoc(this.req, this.res, this.next)
       })
 
-      it('should not update the document', function() {
+      it('should not update the document', function () {
         return this.DocManager.updateDoc.called.should.equal(false)
       })
 
-      return it('should return a 400 (bad request) response', function() {
+      return it('should return a 400 (bad request) response', function () {
         return this.res.send.calledWith(400).should.equal(true)
       })
     })
 
-    describe('when the doc ranges is not provided', function() {
-      beforeEach(function() {
+    describe('when the doc ranges is not provided', function () {
+      beforeEach(function () {
         this.req.body = { lines: ['foo'], version: 42 }
         this.DocManager.updateDoc = sinon.stub().yields(null, false)
         return this.HttpController.updateDoc(this.req, this.res, this.next)
       })
 
-      it('should not update the document', function() {
+      it('should not update the document', function () {
         return this.DocManager.updateDoc.called.should.equal(false)
       })
 
-      return it('should return a 400 (bad request) response', function() {
+      return it('should return a 400 (bad request) response', function () {
         return this.res.send.calledWith(400).should.equal(true)
       })
     })
 
-    return describe('when the doc body is too large', function() {
-      beforeEach(function() {
+    return describe('when the doc body is too large', function () {
+      beforeEach(function () {
         this.req.body = {
           lines: (this.lines = Array(2049).fill('a'.repeat(1024))),
           version: (this.version = 42),
@@ -420,18 +420,18 @@ describe('HttpController', function() {
         return this.HttpController.updateDoc(this.req, this.res, this.next)
       })
 
-      it('should return a 413 (too large) response', function() {
+      it('should return a 413 (too large) response', function () {
         return sinon.assert.calledWith(this.res.status, 413)
       })
 
-      return it('should report that the document body is too large', function() {
+      return it('should report that the document body is too large', function () {
         return sinon.assert.calledWith(this.res.send, 'document body too large')
       })
     })
   })
 
-  describe('deleteDoc', function() {
-    beforeEach(function() {
+  describe('deleteDoc', function () {
+    beforeEach(function () {
       this.req.params = {
         project_id: this.project_id,
         doc_id: this.doc_id
@@ -440,50 +440,50 @@ describe('HttpController', function() {
       return this.HttpController.deleteDoc(this.req, this.res, this.next)
     })
 
-    it('should delete the document', function() {
+    it('should delete the document', function () {
       return this.DocManager.deleteDoc
         .calledWith(this.project_id, this.doc_id)
         .should.equal(true)
     })
 
-    return it('should return a 204 (No Content)', function() {
+    return it('should return a 204 (No Content)', function () {
       return this.res.send.calledWith(204).should.equal(true)
     })
   })
 
-  describe('archiveAllDocs', function() {
-    beforeEach(function() {
+  describe('archiveAllDocs', function () {
+    beforeEach(function () {
       this.req.params = { project_id: this.project_id }
       this.DocArchiveManager.archiveAllDocs = sinon.stub().callsArg(1)
       return this.HttpController.archiveAllDocs(this.req, this.res, this.next)
     })
 
-    it('should archive the project', function() {
+    it('should archive the project', function () {
       return this.DocArchiveManager.archiveAllDocs
         .calledWith(this.project_id)
         .should.equal(true)
     })
 
-    return it('should return a 204 (No Content)', function() {
+    return it('should return a 204 (No Content)', function () {
       return this.res.send.calledWith(204).should.equal(true)
     })
   })
 
-  return describe('destroyAllDocs', function() {
-    beforeEach(function() {
+  return describe('destroyAllDocs', function () {
+    beforeEach(function () {
       this.req.params = { project_id: this.project_id }
       this.DocArchiveManager.destroyAllDocs = sinon.stub().callsArg(1)
       return this.HttpController.destroyAllDocs(this.req, this.res, this.next)
     })
 
-    it('should destroy the docs', function() {
+    it('should destroy the docs', function () {
       return sinon.assert.calledWith(
         this.DocArchiveManager.destroyAllDocs,
         this.project_id
       )
     })
 
-    return it('should return 204', function() {
+    return it('should return 204', function () {
       return sinon.assert.calledWith(this.res.send, 204)
     })
   })

--- a/test/unit/js/MongoManagerTests.js
+++ b/test/unit/js/MongoManagerTests.js
@@ -19,8 +19,8 @@ const modulePath = require('path').join(
 const { ObjectId } = require('mongojs')
 const { assert } = require('chai')
 
-describe('MongoManager', function() {
-  beforeEach(function() {
+describe('MongoManager', function () {
+  beforeEach(function () {
     this.MongoManager = SandboxedModule.require(modulePath, {
       requires: {
         './mongojs': {
@@ -37,8 +37,8 @@ describe('MongoManager', function() {
     return (this.stubbedErr = new Error('hello world'))
   })
 
-  describe('findDoc', function() {
-    beforeEach(function() {
+  describe('findDoc', function () {
+    beforeEach(function () {
       this.doc = { name: 'mock-doc' }
       this.db.docs.find = sinon.stub().callsArgWith(2, null, [this.doc])
       this.filter = { lines: true }
@@ -50,7 +50,7 @@ describe('MongoManager', function() {
       )
     })
 
-    it('should find the doc', function() {
+    it('should find the doc', function () {
       return this.db.docs.find
         .calledWith(
           {
@@ -62,13 +62,13 @@ describe('MongoManager', function() {
         .should.equal(true)
     })
 
-    return it('should call the callback with the doc', function() {
+    return it('should call the callback with the doc', function () {
       return this.callback.calledWith(null, this.doc).should.equal(true)
     })
   })
 
-  describe('getProjectsDocs', function() {
-    beforeEach(function() {
+  describe('getProjectsDocs', function () {
+    beforeEach(function () {
       this.filter = { lines: true }
       this.doc1 = { name: 'mock-doc1' }
       this.doc2 = { name: 'mock-doc2' }
@@ -79,8 +79,8 @@ describe('MongoManager', function() {
         .callsArgWith(2, null, [this.doc, this.doc3, this.doc4]))
     })
 
-    describe('with included_deleted = false', function() {
-      beforeEach(function() {
+    describe('with included_deleted = false', function () {
+      beforeEach(function () {
         return this.MongoManager.getProjectsDocs(
           this.project_id,
           { include_deleted: false },
@@ -89,7 +89,7 @@ describe('MongoManager', function() {
         )
       })
 
-      it('should find the non-deleted docs via the project_id', function() {
+      it('should find the non-deleted docs via the project_id', function () {
         return this.db.docs.find
           .calledWith(
             {
@@ -101,15 +101,15 @@ describe('MongoManager', function() {
           .should.equal(true)
       })
 
-      return it('should call the callback with the docs', function() {
+      return it('should call the callback with the docs', function () {
         return this.callback
           .calledWith(null, [this.doc, this.doc3, this.doc4])
           .should.equal(true)
       })
     })
 
-    return describe('with included_deleted = true', function() {
-      beforeEach(function() {
+    return describe('with included_deleted = true', function () {
+      beforeEach(function () {
         return this.MongoManager.getProjectsDocs(
           this.project_id,
           { include_deleted: true },
@@ -118,7 +118,7 @@ describe('MongoManager', function() {
         )
       })
 
-      it('should find all via the project_id', function() {
+      it('should find all via the project_id', function () {
         return this.db.docs.find
           .calledWith(
             {
@@ -129,7 +129,7 @@ describe('MongoManager', function() {
           .should.equal(true)
       })
 
-      return it('should call the callback with the docs', function() {
+      return it('should call the callback with the docs', function () {
         return this.callback
           .calledWith(null, [this.doc, this.doc3, this.doc4])
           .should.equal(true)
@@ -137,18 +137,18 @@ describe('MongoManager', function() {
     })
   })
 
-  describe('upsertIntoDocCollection', function() {
-    beforeEach(function() {
+  describe('upsertIntoDocCollection', function () {
+    beforeEach(function () {
       this.db.docs.update = sinon.stub().callsArgWith(3, this.stubbedErr)
       return (this.oldRev = 77)
     })
 
-    it('should upsert the document', function(done) {
+    it('should upsert the document', function (done) {
       return this.MongoManager.upsertIntoDocCollection(
         this.project_id,
         this.doc_id,
         { lines: this.lines },
-        err => {
+        (err) => {
           const args = this.db.docs.update.args[0]
           assert.deepEqual(args[0], { _id: ObjectId(this.doc_id) })
           assert.equal(args[1].$set.lines, this.lines)
@@ -159,12 +159,12 @@ describe('MongoManager', function() {
       )
     })
 
-    return it('should return the error', function(done) {
+    return it('should return the error', function (done) {
       return this.MongoManager.upsertIntoDocCollection(
         this.project_id,
         this.doc_id,
         { lines: this.lines },
-        err => {
+        (err) => {
           err.should.equal(this.stubbedErr)
           return done()
         }
@@ -172,17 +172,17 @@ describe('MongoManager', function() {
     })
   })
 
-  describe('markDocAsDeleted', function() {
-    beforeEach(function() {
+  describe('markDocAsDeleted', function () {
+    beforeEach(function () {
       this.db.docs.update = sinon.stub().callsArgWith(2, this.stubbedErr)
       return (this.oldRev = 77)
     })
 
-    it('should process the update', function(done) {
+    it('should process the update', function (done) {
       return this.MongoManager.markDocAsDeleted(
         this.project_id,
         this.doc_id,
-        err => {
+        (err) => {
           const args = this.db.docs.update.args[0]
           assert.deepEqual(args[0], {
             _id: ObjectId(this.doc_id),
@@ -194,11 +194,11 @@ describe('MongoManager', function() {
       )
     })
 
-    return it('should return the error', function(done) {
+    return it('should return the error', function (done) {
       return this.MongoManager.markDocAsDeleted(
         this.project_id,
         this.doc_id,
-        err => {
+        (err) => {
           err.should.equal(this.stubbedErr)
           return done()
         }
@@ -206,59 +206,59 @@ describe('MongoManager', function() {
     })
   })
 
-  describe('destroyDoc', function() {
-    beforeEach(function(done) {
+  describe('destroyDoc', function () {
+    beforeEach(function (done) {
       this.db.docs.remove = sinon.stub().yields()
       this.db.docOps.remove = sinon.stub().yields()
       return this.MongoManager.destroyDoc('123456789012', done)
     })
 
-    it('should destroy the doc', function() {
+    it('should destroy the doc', function () {
       return sinon.assert.calledWith(this.db.docs.remove, {
         _id: ObjectId('123456789012')
       })
     })
 
-    return it('should destroy the docOps', function() {
+    return it('should destroy the docOps', function () {
       return sinon.assert.calledWith(this.db.docOps.remove, {
         doc_id: ObjectId('123456789012')
       })
     })
   })
 
-  describe('getDocVersion', function() {
-    describe('when the doc exists', function() {
-      beforeEach(function() {
+  describe('getDocVersion', function () {
+    describe('when the doc exists', function () {
+      beforeEach(function () {
         this.doc = { version: (this.version = 42) }
         this.db.docOps.find = sinon.stub().callsArgWith(2, null, [this.doc])
         return this.MongoManager.getDocVersion(this.doc_id, this.callback)
       })
 
-      it('should look for the doc in the database', function() {
+      it('should look for the doc in the database', function () {
         return this.db.docOps.find
           .calledWith({ doc_id: ObjectId(this.doc_id) }, { version: 1 })
           .should.equal(true)
       })
 
-      return it('should call the callback with the version', function() {
+      return it('should call the callback with the version', function () {
         return this.callback.calledWith(null, this.version).should.equal(true)
       })
     })
 
-    return describe("when the doc doesn't exist", function() {
-      beforeEach(function() {
+    return describe("when the doc doesn't exist", function () {
+      beforeEach(function () {
         this.db.docOps.find = sinon.stub().callsArgWith(2, null, [])
         return this.MongoManager.getDocVersion(this.doc_id, this.callback)
       })
 
-      return it('should call the callback with 0', function() {
+      return it('should call the callback with 0', function () {
         return this.callback.calledWith(null, 0).should.equal(true)
       })
     })
   })
 
-  return describe('setDocVersion', function() {
-    beforeEach(function() {
+  return describe('setDocVersion', function () {
+    beforeEach(function () {
       this.version = 42
       this.db.docOps.update = sinon.stub().callsArg(3)
       return this.MongoManager.setDocVersion(
@@ -268,7 +268,7 @@ describe('MongoManager', function() {
       )
     })
 
-    it('should update the doc version', function() {
+    it('should update the doc version', function () {
       return this.db.docOps.update
         .calledWith(
           {
@@ -286,7 +286,7 @@ describe('MongoManager', function() {
         .should.equal(true)
     })
 
-    return it('should call the callback', function() {
+    return it('should call the callback', function () {
       return this.callback.called.should.equal(true)
     })
   })

--- a/test/unit/js/RangeManagerTests.js
+++ b/test/unit/js/RangeManagerTests.js
@@ -22,8 +22,8 @@ const { ObjectId } = require('mongojs')
 const { assert } = require('chai')
 const _ = require('underscore')
 
-describe('RangeManager', function() {
-  beforeEach(function() {
+describe('RangeManager', function () {
+  beforeEach(function () {
     return (this.RangeManager = SandboxedModule.require(modulePath, {
       requires: {
         './mongojs': {
@@ -33,8 +33,8 @@ describe('RangeManager', function() {
     }))
   })
 
-  describe('jsonRangesToMongo', function() {
-    it('should convert ObjectIds and dates to proper objects', function() {
+  describe('jsonRangesToMongo', function () {
+    it('should convert ObjectIds and dates to proper objects', function () {
       const change_id = ObjectId().toString()
       const comment_id = ObjectId().toString()
       const user_id = ObjectId().toString()
@@ -77,7 +77,7 @@ describe('RangeManager', function() {
       })
     })
 
-    it('should leave malformed ObjectIds as they are', function() {
+    it('should leave malformed ObjectIds as they are', function () {
       const change_id = 'foo'
       const comment_id = 'bar'
       const user_id = 'baz'
@@ -112,7 +112,7 @@ describe('RangeManager', function() {
       })
     })
 
-    return it('should be consistent when transformed through json -> mongo -> json', function() {
+    return it('should be consistent when transformed through json -> mongo -> json', function () {
       const change_id = ObjectId().toString()
       const comment_id = ObjectId().toString()
       const user_id = ObjectId().toString()
@@ -144,8 +144,8 @@ describe('RangeManager', function() {
     })
   })
 
-  return describe('shouldUpdateRanges', function() {
-    beforeEach(function() {
+  return describe('shouldUpdateRanges', function () {
+    beforeEach(function () {
       this.ranges = {
         changes: [
           {
@@ -169,16 +169,16 @@ describe('RangeManager', function() {
       ))
     })
 
-    describe('with a blank new range', function() {
-      return it('should throw an error', function() {
+    describe('with a blank new range', function () {
+      return it('should throw an error', function () {
         return expect(() => {
           return this.RangeManager.shouldUpdateRanges(this.ranges, null)
         }).to.throw(Error)
       })
     })
 
-    describe('with a blank old range', function() {
-      return it('should treat it like {}', function() {
+    describe('with a blank old range', function () {
+      return it('should treat it like {}', function () {
         this.RangeManager.shouldUpdateRanges(null, {}).should.equal(false)
         return this.RangeManager.shouldUpdateRanges(
           null,
@@ -187,8 +187,8 @@ describe('RangeManager', function() {
       })
     })
 
-    describe('with no changes', function() {
-      return it('should return false', function() {
+    describe('with no changes', function () {
+      return it('should return false', function () {
         return this.RangeManager.shouldUpdateRanges(
           this.ranges,
           this.ranges_copy
@@ -196,8 +196,8 @@ describe('RangeManager', function() {
       })
     })
 
-    return describe('with changes', function() {
-      it('should return true when the change id changes', function() {
+    return describe('with changes', function () {
+      it('should return true when the change id changes', function () {
         this.ranges_copy.changes[0].id = ObjectId()
         return this.RangeManager.shouldUpdateRanges(
           this.ranges,
@@ -205,7 +205,7 @@ describe('RangeManager', function() {
         ).should.equal(true)
       })
 
-      it('should return true when the change user id changes', function() {
+      it('should return true when the change user id changes', function () {
         this.ranges_copy.changes[0].metadata.user_id = ObjectId()
         return this.RangeManager.shouldUpdateRanges(
           this.ranges,
@@ -213,7 +213,7 @@ describe('RangeManager', function() {
         ).should.equal(true)
       })
 
-      it('should return true when the change ts changes', function() {
+      it('should return true when the change ts changes', function () {
         this.ranges_copy.changes[0].metadata.ts = new Date(Date.now() + 1000)
         return this.RangeManager.shouldUpdateRanges(
           this.ranges,
@@ -221,7 +221,7 @@ describe('RangeManager', function() {
         ).should.equal(true)
       })
 
-      it('should return true when the change op changes', function() {
+      it('should return true when the change op changes', function () {
         this.ranges_copy.changes[0].op.i = 'bar'
         return this.RangeManager.shouldUpdateRanges(
           this.ranges,
@@ -229,7 +229,7 @@ describe('RangeManager', function() {
         ).should.equal(true)
       })
 
-      it('should return true when the comment id changes', function() {
+      it('should return true when the comment id changes', function () {
         this.ranges_copy.comments[0].id = ObjectId()
         return this.RangeManager.shouldUpdateRanges(
           this.ranges,
@@ -237,7 +237,7 @@ describe('RangeManager', function() {
         ).should.equal(true)
       })
 
-      it('should return true when the comment offset changes', function() {
+      it('should return true when the comment offset changes', function () {
         this.ranges_copy.comments[0].op.p = 17
         return this.RangeManager.shouldUpdateRanges(
           this.ranges,
@@ -245,7 +245,7 @@ describe('RangeManager', function() {
         ).should.equal(true)
       })
 
-      return it('should return true when the comment content changes', function() {
+      return it('should return true when the comment content changes', function () {
         this.ranges_copy.comments[0].op.c = 'bar'
         return this.RangeManager.shouldUpdateRanges(
           this.ranges,


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Fix formatting by running `make format_fix`, which required and upgrade of the build scripts first to get the fix paths (`'**/*.js'` => `$PWD'/**/*.js'`).


#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3090

### Review

This will conflict with https://github.com/overleaf/docstore/pull/56 (which BTW you might have forgotten about @das7pad ?) So I pushed a  new branch, `ew-jpa-fix-express-deprecations-pretty` rebased on top of this one and fixing the conflicts. I'll leave it it with you to force-push the PR branch @das7pad 