### PR TITLE
[misc] simplify mongodb collection access using a shared db construct

### DIFF
--- a/app/js/HealthChecker.js
+++ b/app/js/HealthChecker.js
@@ -10,7 +10,7 @@
  * DS207: Consider shorter variations of null checks
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
  */
-const { getCollection, ObjectId } = require('./mongodb')
+const { db, ObjectId } = require('./mongodb')
 const request = require('request')
 const async = require('async')
 const _ = require('underscore')
@@ -18,9 +18,6 @@ const crypto = require('crypto')
 const settings = require('settings-sharelatex')
 const { port } = settings.internal.docstore
 const logger = require('logger-sharelatex')
-
-const docsCollectionPromise = getCollection('docs')
-const docOpsCollectionPromise = getCollection('docOps')
 
 module.exports = {
   check(callback) {
@@ -63,14 +60,8 @@ module.exports = {
           }
         })
       },
-      (cb) =>
-        docsCollectionPromise.then((docs) =>
-          docs.deleteOne({ _id: doc_id, project_id }, cb)
-        ),
-      (cb) =>
-        docOpsCollectionPromise.then((docOps) =>
-          docOps.deleteOne({ doc_id }, cb)
-        )
+      (cb) => db.docs.deleteOne({ _id: doc_id, project_id }, cb),
+      (cb) => db.docOps.deleteOne({ doc_id }, cb)
     ]
     return async.series(jobs, callback)
   }

--- a/app/js/MongoManager.js
+++ b/app/js/MongoManager.js
@@ -26,7 +26,9 @@ module.exports = MongoManager = {
         _id: ObjectId(doc_id.toString()),
         project_id: ObjectId(project_id.toString())
       },
-      filter,
+      {
+        projection: filter
+      },
       callback
     )
   },
@@ -39,7 +41,11 @@ module.exports = MongoManager = {
     if (!options.include_deleted) {
       query.deleted = { $ne: true }
     }
-    db.docs.find(query, filter).toArray(callback)
+    db.docs
+      .find(query, {
+        projection: filter
+      })
+      .toArray(callback)
   },
 
   getArchivedProjectDocs(project_id, callback) {
@@ -106,7 +112,9 @@ module.exports = MongoManager = {
         doc_id: ObjectId(doc_id)
       },
       {
-        version: 1
+        projection: {
+          version: 1
+        }
       },
       function (error, doc) {
         if (error != null) {

--- a/app/js/mongodb.js
+++ b/app/js/mongodb.js
@@ -1,7 +1,10 @@
 const Settings = require('settings-sharelatex')
 const { MongoClient, ObjectId } = require('mongodb')
 
-const clientPromise = MongoClient.connect(Settings.mongo.url)
+const clientPromise = MongoClient.connect(
+  Settings.mongo.url,
+  Settings.mongo.options
+)
 
 let setupDbPromise
 async function waitForDb() {

--- a/app/js/mongodb.js
+++ b/app/js/mongodb.js
@@ -2,18 +2,21 @@ const Settings = require('settings-sharelatex')
 const { MongoClient, ObjectId } = require('mongodb')
 
 const clientPromise = MongoClient.connect(Settings.mongo.url)
-const dbPromise = clientPromise.then((client) => client.db())
-
-async function getCollection(name) {
-  return (await dbPromise).collection(name)
-}
 
 async function waitForDb() {
   await clientPromise
 }
 
+const db = {}
+waitForDb().then(async function () {
+  const internalDb = (await clientPromise).db()
+
+  db.docs = internalDb.collection('docs')
+  db.docOps = internalDb.collection('docOps')
+})
+
 module.exports = {
+  db,
   ObjectId,
-  getCollection,
   waitForDb
 }

--- a/app/js/mongodb.js
+++ b/app/js/mongodb.js
@@ -3,17 +3,21 @@ const { MongoClient, ObjectId } = require('mongodb')
 
 const clientPromise = MongoClient.connect(Settings.mongo.url)
 
+let setupDbPromise
 async function waitForDb() {
-  await clientPromise
+  if (!setupDbPromise) {
+    setupDbPromise = setupDb()
+  }
+  await setupDbPromise
 }
 
 const db = {}
-waitForDb().then(async function () {
+async function setupDb() {
   const internalDb = (await clientPromise).db()
 
   db.docs = internalDb.collection('docs')
   db.docOps = internalDb.collection('docOps')
-})
+}
 
 module.exports = {
   db,

--- a/app/js/mongodb.js
+++ b/app/js/mongodb.js
@@ -18,9 +18,16 @@ async function setupDb() {
   db.docs = internalDb.collection('docs')
   db.docOps = internalDb.collection('docOps')
 }
+async function addCollection(name) {
+  await waitForDb()
+  const internalDb = (await clientPromise).db()
+
+  db[name] = internalDb.collection(name)
+}
 
 module.exports = {
   db,
   ObjectId,
+  addCollection,
   waitForDb
 }

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -14,7 +14,12 @@ const Settings = {
     }
   },
 
-  mongo: {},
+  mongo: {
+    options: {
+      useUnifiedTopology:
+        (process.env.MONGO_USE_UNIFIED_TOPOLOGY || 'true') === 'true'
+    }
+  },
 
   docstore: {
     backend: process.env.BACKEND || 's3',

--- a/test/acceptance/js/ArchiveDocsTests.js
+++ b/test/acceptance/js/ArchiveDocsTests.js
@@ -17,7 +17,7 @@ const Settings = require('settings-sharelatex')
 const chai = require('chai')
 const { expect } = chai
 const should = chai.should()
-const { getCollection, ObjectId } = require('../../../app/js/mongodb')
+const { db, ObjectId } = require('../../../app/js/mongodb')
 const async = require('async')
 const DocstoreApp = require('./helpers/DocstoreApp')
 const DocstoreClient = require('./helpers/DocstoreClient')
@@ -31,14 +31,6 @@ function uploadContent(path, json, callback) {
     .then(() => callback())
     .catch(callback)
 }
-
-let db
-before(async function () {
-  db = {
-    docs: await getCollection('docs'),
-    docOps: await getCollection('docOps')
-  }
-})
 
 describe('Archiving', function () {
   before(function (done) {

--- a/test/acceptance/js/DeletingDocsTests.js
+++ b/test/acceptance/js/DeletingDocsTests.js
@@ -13,20 +13,12 @@
  */
 const chai = require('chai')
 chai.should()
-const { getCollection, ObjectId } = require('../../../app/js/mongodb')
+const { db, ObjectId } = require('../../../app/js/mongodb')
 const { expect } = chai
 const DocstoreApp = require('./helpers/DocstoreApp')
 const Errors = require('../../../app/js/Errors')
 
 const DocstoreClient = require('./helpers/DocstoreClient')
-
-let db
-before(async function () {
-  db = {
-    docs: await getCollection('docs'),
-    docOps: await getCollection('docOps')
-  }
-})
 
 describe('Deleting a doc', function () {
   beforeEach(function (done) {

--- a/test/acceptance/js/helpers/DocstoreApp.js
+++ b/test/acceptance/js/helpers/DocstoreApp.js
@@ -12,6 +12,7 @@
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
  */
 const app = require('../../../../app')
+const { waitForDb } = require('../../../../app/js/mongodb')
 require('logger-sharelatex').logger.level('error')
 const settings = require('settings-sharelatex')
 
@@ -27,9 +28,10 @@ module.exports = {
       return callback()
     } else if (this.initing) {
       return this.callbacks.push(callback)
-    } else {
-      this.initing = true
-      this.callbacks.push(callback)
+    }
+    this.initing = true
+    this.callbacks.push(callback)
+    waitForDb().then(() => {
       return app.listen(
         settings.internal.docstore.port,
         'localhost',
@@ -47,6 +49,6 @@ module.exports = {
           })()
         }
       )
-    }
+    })
   }
 }

--- a/test/unit/js/MongoManagerTests.js
+++ b/test/unit/js/MongoManagerTests.js
@@ -21,13 +21,9 @@ const { assert } = require('chai')
 
 describe('MongoManager', function () {
   beforeEach(function () {
-    this.db = {}
     this.MongoManager = SandboxedModule.require(modulePath, {
       requires: {
         './mongodb': {
-          getCollection: sinon.stub().callsFake((name) => {
-            return Promise.resolve((this.db[name] = {}))
-          }),
           db: (this.db = { docs: {}, docOps: {} }),
           ObjectId
         },
@@ -40,12 +36,12 @@ describe('MongoManager', function () {
     })
     this.project_id = ObjectId().toString()
     this.doc_id = ObjectId().toString()
+    this.callback = sinon.stub()
     return (this.stubbedErr = new Error('hello world'))
   })
 
   describe('findDoc', function () {
-    beforeEach(function (done) {
-      this.callback = sinon.stub().callsFake(() => done())
+    beforeEach(function () {
       this.doc = { name: 'mock-doc' }
       this.db.docs.findOne = sinon.stub().callsArgWith(2, null, this.doc)
       this.filter = { lines: true }
@@ -89,8 +85,7 @@ describe('MongoManager', function () {
     })
 
     describe('with included_deleted = false', function () {
-      beforeEach(function (done) {
-        this.callback = sinon.stub().callsFake(() => done())
+      beforeEach(function () {
         return this.MongoManager.getProjectsDocs(
           this.project_id,
           { include_deleted: false },
@@ -119,8 +114,7 @@ describe('MongoManager', function () {
     })
 
     return describe('with included_deleted = true', function () {
-      beforeEach(function (done) {
-        this.callback = sinon.stub().callsFake(() => done())
+      beforeEach(function () {
         return this.MongoManager.getProjectsDocs(
           this.project_id,
           { include_deleted: true },
@@ -239,8 +233,7 @@ describe('MongoManager', function () {
 
   describe('getDocVersion', function () {
     describe('when the doc exists', function () {
-      beforeEach(function (done) {
-        this.callback = sinon.stub().callsFake(() => done())
+      beforeEach(function () {
         this.doc = { version: (this.version = 42) }
         this.db.docOps.findOne = sinon.stub().callsArgWith(2, null, this.doc)
         return this.MongoManager.getDocVersion(this.doc_id, this.callback)
@@ -258,8 +251,7 @@ describe('MongoManager', function () {
     })
 
     return describe("when the doc doesn't exist", function () {
-      beforeEach(function (done) {
-        this.callback = sinon.stub().callsFake(() => done())
+      beforeEach(function () {
         this.db.docOps.findOne = sinon.stub().callsArgWith(2, null, null)
         return this.MongoManager.getDocVersion(this.doc_id, this.callback)
       })
@@ -271,8 +263,7 @@ describe('MongoManager', function () {
   })
 
   return describe('setDocVersion', function () {
-    beforeEach(function (done) {
-      this.callback = sinon.stub().callsFake(() => done())
+    beforeEach(function () {
       this.version = 42
       this.db.docOps.updateOne = sinon.stub().callsArg(3)
       return this.MongoManager.setDocVersion(

--- a/test/unit/js/MongoManagerTests.js
+++ b/test/unit/js/MongoManagerTests.js
@@ -60,7 +60,9 @@ describe('MongoManager', function () {
             _id: ObjectId(this.doc_id),
             project_id: ObjectId(this.project_id)
           },
-          this.filter
+          {
+            projection: this.filter
+          }
         )
         .should.equal(true)
     })
@@ -101,7 +103,9 @@ describe('MongoManager', function () {
               project_id: ObjectId(this.project_id),
               deleted: { $ne: true }
             },
-            this.filter
+            {
+              projection: this.filter
+            }
           )
           .should.equal(true)
       })
@@ -129,7 +133,9 @@ describe('MongoManager', function () {
             {
               project_id: ObjectId(this.project_id)
             },
-            this.filter
+            {
+              projection: this.filter
+            }
           )
           .should.equal(true)
       })
@@ -241,7 +247,12 @@ describe('MongoManager', function () {
 
       it('should look for the doc in the database', function () {
         return this.db.docOps.findOne
-          .calledWith({ doc_id: ObjectId(this.doc_id) }, { version: 1 })
+          .calledWith(
+            { doc_id: ObjectId(this.doc_id) },
+            {
+              projection: { version: 1 }
+            }
+          )
           .should.equal(true)
       })
 


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/2907
Copied from https://github.com/overleaf/chat/pull/57

> Resolve the getCollection Promises once and store the result in a shared
 `db` object which can get imported by all the call-sites.
>
> The http server is starting only after a Promise of `waitForDb()`
 resolves. This covers the app code and the acceptance tests.

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/2907
https://github.com/overleaf/chat/pull/57

### Review

This is best reviewed locally, comparing the PR revision with master prior to the mongodb-native merge.

#### Potential Impact

High. All mongo interaction changed.

#### Manual Testing Performed

- editor works for a brand new project
- compiles work
- run acceptance tests
