### PR TITLE
[misc] run the codemod for moving mongo projections into options

### DIFF
--- a/app/js/MongoManager.js
+++ b/app/js/MongoManager.js
@@ -26,7 +26,9 @@ module.exports = MongoManager = {
         _id: ObjectId(doc_id.toString()),
         project_id: ObjectId(project_id.toString())
       },
-      filter,
+      {
+        projection: filter
+      },
       callback
     )
   },
@@ -39,7 +41,11 @@ module.exports = MongoManager = {
     if (!options.include_deleted) {
       query.deleted = { $ne: true }
     }
-    db.docs.find(query, filter).toArray(callback)
+    db.docs
+      .find(query, {
+        projection: filter
+      })
+      .toArray(callback)
   },
 
   getArchivedProjectDocs(project_id, callback) {
@@ -106,7 +112,9 @@ module.exports = MongoManager = {
         doc_id: ObjectId(doc_id)
       },
       {
-        version: 1
+        projection: {
+          version: 1
+        }
       },
       function (error, doc) {
         if (error != null) {

--- a/scripts/rearchive-all-docs.js
+++ b/scripts/rearchive-all-docs.js
@@ -84,7 +84,11 @@ async function rearchiveAllDocs() {
   }
 
   await addCollection('projects')
-  const results = db.projects.find(query, { _id: 1 }).sort({ _id: 1 })
+  const results = db.projects
+    .find(query, {
+      projection: { _id: 1 }
+    })
+    .sort({ _id: 1 })
   let jobCount = 0
 
   // keep going until we run out of projects

--- a/test/unit/js/MongoManagerTests.js
+++ b/test/unit/js/MongoManagerTests.js
@@ -60,7 +60,9 @@ describe('MongoManager', function () {
             _id: ObjectId(this.doc_id),
             project_id: ObjectId(this.project_id)
           },
-          this.filter
+          {
+            projection: this.filter
+          }
         )
         .should.equal(true)
     })
@@ -101,7 +103,9 @@ describe('MongoManager', function () {
               project_id: ObjectId(this.project_id),
               deleted: { $ne: true }
             },
-            this.filter
+            {
+              projection: this.filter
+            }
           )
           .should.equal(true)
       })
@@ -129,7 +133,9 @@ describe('MongoManager', function () {
             {
               project_id: ObjectId(this.project_id)
             },
-            this.filter
+            {
+              projection: this.filter
+            }
           )
           .should.equal(true)
       })
@@ -241,7 +247,12 @@ describe('MongoManager', function () {
 
       it('should look for the doc in the database', function () {
         return this.db.docOps.findOne
-          .calledWith({ doc_id: ObjectId(this.doc_id) }, { version: 1 })
+          .calledWith(
+            { doc_id: ObjectId(this.doc_id) },
+            {
+              projection: { version: 1 }
+            }
+          )
           .should.equal(true)
       })
 


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/2907
Chained onto https://github.com/overleaf/docstore/pull/67

The native mongo driver has removed the support for a projection as second parameter for `find`/`findOne`.
This PR contains the changes of the codemod https://github.com/overleaf/dev-environment/pull/390 for transforming mongo find projections into the find options.

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/2907
https://github.com/overleaf/dev-environment/pull/390

#### Potential Impact

High. Affects all find queries.

#### Manual Testing Performed

- run acceptance tests
