### PR TITLE
[misc] mongodb: use the new db connector by default

### DIFF
--- a/app/js/mongodb.js
+++ b/app/js/mongodb.js
@@ -1,7 +1,10 @@
 const Settings = require('settings-sharelatex')
 const { MongoClient, ObjectId } = require('mongodb')
 
-const clientPromise = MongoClient.connect(Settings.mongo.url)
+const clientPromise = MongoClient.connect(
+  Settings.mongo.url,
+  Settings.mongo.options
+)
 
 let setupDbPromise
 async function waitForDb() {

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -14,7 +14,12 @@ const Settings = {
     }
   },
 
-  mongo: {},
+  mongo: {
+    options: {
+      useUnifiedTopology:
+        (process.env.MONGO_USE_UNIFIED_TOPOLOGY || 'true') === 'true'
+    }
+  },
 
   docstore: {
     backend: process.env.BACKEND || 's3',


### PR DESCRIPTION
### Description

Sibling of https://github.com/overleaf/chat/pull/60

> This PR is bringing back a changed default from mongojs that I did not spot initially.
>
>[mongojs is changing the underlying connector to the new `unifiedTopology`.](https://github.com/mongo-js/mongojs/blob/df1fb993c379ff48537d3028f6722eaf6f5db014/lib/database.js#L13)
>
>This change has been tested in staging as part of https://github.com/overleaf/issues/issues/3489
>
>I added a config option that allows us to flip back at any time in the future in case we see issues (using `MONGO_USE_UNIFIED_TOPOLOGY=false`).

Chained onto #67 

#### Related Issues / PRs

https://github.com/overleaf/chat/pull/60
https://github.com/overleaf/issues/issues/3489
https://github.com/overleaf/issues/issues/2907

#### Potential Impact

High. The service does not start without a mongo connection. We were using it with mongojs before, so this should be safe.

#### Manual Testing Performed

Performed with the chat service:

- point the mongo host to localhost, pod is not starting
- point mongo back to the db-host, pod is starting

