### PR TITLE
Replace tiny-async-pool with p-map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1382,6 +1382,15 @@
         }
       }
     },
+    "aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
+    },
     "ajv": {
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
@@ -1887,6 +1896,11 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.2.0"
       }
+    },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
     "cli-cursor": {
       "version": "3.1.0",
@@ -3603,8 +3617,7 @@
     "indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -4835,6 +4848,14 @@
           "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
           "dev": true
         }
+      }
+    },
+    "p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "requires": {
+        "aggregate-error": "^3.0.0"
       }
     },
     "p-try": {

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "logger-sharelatex": "^2.2.0",
     "metrics-sharelatex": "^2.7.0",
     "mongodb": "^3.6.0",
+    "p-map": "^4.0.0",
     "settings-sharelatex": "^1.1.0",
     "streamifier": "^0.1.1",
-    "tiny-async-pool": "^1.1.0",
     "underscore": "~1.10.2"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

`tiny-async-pool` creates spurious errors in the logs. See #72  - The bug that causes the logged errors is fixed upstream in `master`, but not released.

`p-map` looks like a good alternative that does the same thing and is lightweight.

#### Related Issues / PRs

See #72 
Source of most of the log noise in overleaf/issues#3429

### Review

Pleasingly, the unit tests pass without modification. I hadn't stubbed the `asyncPool` behaviour previously.

#### Potential Impact

Affects archiving/unarchiving/deletion

#### Manual Testing Performed

- [ ] Archive and unarchive a project
