### PR TITLE
[misc] install @overleaf/object-persistor from tar-ball

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1062,8 +1062,8 @@
       "integrity": "sha512-LsM2s6Iy9G97ktPo0ys4VxtI/m3ahc1ZHwjo5XnhXtjeIkkkVAehsrcRRoV/yWepPjymB0oZonhcfojpjYR/tg=="
     },
     "@overleaf/object-persistor": {
-      "version": "git+https://github.com/overleaf/object-persistor.git#4ca62157a2beb747e9a56da3ce1569124b90378a",
-      "from": "git+https://github.com/overleaf/object-persistor.git",
+      "version": "https://github.com/overleaf/object-persistor/archive/4ca62157a2beb747e9a56da3ce1569124b90378a.tar.gz",
+      "integrity": "sha512-7USiK1g94cFnREqPqtsvmw0OevEYb6wtnBP7mFA4akjz/YqSM+yTrQnobt8TuBmnzRgGabRmQ8yaeBGEzhmxnA==",
       "requires": {
         "@google-cloud/storage": "^5.1.2",
         "@overleaf/o-error": "^3.0.0",
@@ -1088,6 +1088,11 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
         }
       }
     },
@@ -4788,11 +4793,6 @@
           }
         }
       }
-    },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
     },
     "nopt": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@overleaf/metrics": "^3.4.1",
-    "@overleaf/object-persistor": "git+https://github.com/overleaf/object-persistor.git",
+    "@overleaf/object-persistor": "https://github.com/overleaf/object-persistor/archive/4ca62157a2beb747e9a56da3ce1569124b90378a.tar.gz",
     "async": "^2.6.3",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/3731

Installing npm packages via git is flaky (https://github.com/overleaf/third-party-references/pull/42).
This PR is switching the installation of the @overleaf/object-persistor package to a tar-ball install.

Note: The installed version is fairly out-dated. Shall I create a ticket for upgrading it (in a follow-up PR)? @gh2k 
https://github.com/overleaf/object-persistor/compare/4ca62157a2beb747e9a56da3ce1569124b90378a..master

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/3731

#### Potential Impact

Low. The tests are not working without this package being properly installed, so the chance of it breaking in prod are low.
