### PR TITLE
[misc] fix ci -- pin fake-gcs to a compatible version

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -56,7 +56,7 @@ services:
       interval: 1s
       retries: 20
   gcs:
-    image: fsouza/fake-gcs-server
+    image: fsouza/fake-gcs-server:v1.21.2
     command: ["--port=9090", "--scheme=http"]
     healthcheck:
       test: wget --quiet --output-document=/dev/null http://localhost:9090/storage/v1/b

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       retries: 20
 
   gcs:
-    image: fsouza/fake-gcs-server
+    image: fsouza/fake-gcs-server:v1.21.2
     command: ["--port=9090", "--scheme=http"]
     healthcheck:
       test: wget --quiet --output-document=/dev/null http://localhost:9090/storage/v1/b


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Workaround for https://github.com/overleaf/issues/issues/3890

CI is failing with the latest fake-gcs version. This PR is pinning an old version that was in use locally.

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3890

#### Potential Impact

Low.

#### Manual Testing Performed

- `$ make test_acceptance` passes
