### PR TITLE
[app] add a new route for archiving a single doc

### DIFF
--- a/app.js
+++ b/app.js
@@ -56,6 +56,7 @@ app.post(
 app.delete('/project/:project_id/doc/:doc_id', HttpController.deleteDoc)
 
 app.post('/project/:project_id/archive', HttpController.archiveAllDocs)
+app.post('/project/:project_id/doc/:doc_id/archive', HttpController.archiveDoc)
 app.post('/project/:project_id/unarchive', HttpController.unArchiveAllDocs)
 app.post('/project/:project_id/destroy', HttpController.destroyAllDocs)
 

--- a/app/js/HttpController.js
+++ b/app/js/HttpController.js
@@ -222,6 +222,17 @@ module.exports = HttpController = {
     })
   },
 
+  archiveDoc(req, res, next) {
+    const { project_id, doc_id } = req.params
+    logger.log({ project_id, doc_id }, 'archiving a doc')
+    DocArchive.archiveDocById(project_id, doc_id, function (error) {
+      if (error) {
+        return next(error)
+      }
+      res.sendStatus(204)
+    })
+  },
+
   unArchiveAllDocs(req, res, next) {
     if (next == null) {
       next = function (error) {}

--- a/test/acceptance/js/helpers/DocstoreClient.js
+++ b/test/acceptance/js/helpers/DocstoreClient.js
@@ -129,6 +129,18 @@ module.exports = DocstoreClient = {
     )
   },
 
+  archiveDocById(project_id, doc_id, callback) {
+    if (callback == null) {
+      callback = function (error, res, body) {}
+    }
+    return request.post(
+      {
+        url: `http://localhost:${settings.internal.docstore.port}/project/${project_id}/doc/${doc_id}/archive`
+      },
+      callback
+    )
+  },
+
   destroyAllDoc(project_id, callback) {
     if (callback == null) {
       callback = function (error, res, body) {}


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

For https://github.com/overleaf/issues/issues/3733
Chained onto https://github.com/overleaf/docstore/pull/83 for a CI fix

This PR is adding a route for archiving a single doc out of mongo.

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/3733


### Review

The naming in DocArchiveManager.js is a bit strange now, but I did not
 want to refactor the _internal_ method `archiveDoc` which takes a mongo
 document as second parameter.
There is a minor opportunity for optimizing the mongo call(s) for
 archiving: we should include `{ inS3: false }` in the queries instead
 of filtering locally. It's been like that for years now, so it can
 stay a little longer.

#### Potential Impact

Low. Added route.

#### Manual Testing Performed

- see added acceptance
