### PR TITLE
[DocManager] optionally flush docs out of mongo when deleting them

### DIFF
--- a/app/js/DocManager.js
+++ b/app/js/DocManager.js
@@ -20,6 +20,7 @@ const logger = require('logger-sharelatex')
 const _ = require('underscore')
 const DocArchive = require('./DocArchiveManager')
 const RangeManager = require('./RangeManager')
+const Settings = require('settings-sharelatex')
 
 module.exports = DocManager = {
   // TODO: For historical reasons, the doc version is currently stored in the docOps
@@ -304,6 +305,19 @@ module.exports = DocManager = {
           )
         )
       }
+
+      if (Settings.docstore.archiveOnSoftDelete) {
+        // The user will not read this doc anytime soon. Flush it out of mongo.
+        DocArchive.archiveDocById(project_id, doc_id, (err) => {
+          if (err) {
+            logger.warn(
+              { project_id, doc_id, err },
+              'archiving a single doc in the background failed'
+            )
+          }
+        })
+      }
+
       return MongoManager.markDocAsDeleted(project_id, doc_id, callback)
     })
   }

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -22,6 +22,8 @@ const Settings = {
   },
 
   docstore: {
+    archiveOnSoftDelete: process.env.ARCHIVE_ON_SOFT_DELETE === 'true',
+
     backend: process.env.BACKEND || 's3',
     healthCheck: {
       project_id: process.env.HEALTH_CHECK_PROJECT_ID


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/3733
Chained onto https://github.com/overleaf/docstore/pull/84

Instead of firing an additional docstore request from the deletion process in web, we can flush docs out of mongo as part of the soft deletion process.

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/3733

### Review

I put this behind a feature flag in the settings for now.

I think it is worth flushing docs out of mongo no matter how large the deletedDocs array already is -- the user will not look at the doc any time soon. In case we want to flush out of mongo for those large projects only, we could pass a query flag from the http request into the DocManager. 

#### Potential Impact

Low. New logic is behind feature flag.

#### Manual Testing Performed

- added acceptance test
- added unit test
