### PR TITLE
[misc] MongoManager: drop unused, potentially expensive default options

### DIFF
--- a/app/js/MongoManager.js
+++ b/app/js/MongoManager.js
@@ -34,9 +34,6 @@ module.exports = MongoManager = {
   },
 
   getProjectsDocs(project_id, options, filter, callback) {
-    if (options == null) {
-      options = { include_deleted: true }
-    }
     const query = { project_id: ObjectId(project_id.toString()) }
     if (!options.include_deleted) {
       query.deleted = { $ne: true }


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/3733

This PR is cleaning up an unused default that may incur high bandwidth/storage costs when used without care.
Without this _loop hole_ it is much simpler to reason about potential uses for deleted docs -> https://github.com/overleaf/issues/issues/3733#issuecomment-754060726.

#### Related Issues / PRs


For https://github.com/overleaf/issues/issues/3733

### Review

All call-sites provide an options object.


#### Potential Impact

Low. No call-site is using it.
