### PR TITLE
[DocArchiveManager] optionally do not un-archive soft deleted docs

### DIFF
--- a/app/js/DocArchiveManager.js
+++ b/app/js/DocArchiveManager.js
@@ -100,7 +100,12 @@ async function archiveDoc(projectId, doc) {
 }
 
 async function unArchiveAllDocs(projectId) {
-  const docs = await MongoManager.getArchivedProjectDocs(projectId)
+  let docs
+  if (settings.docstore.keepSoftDeletedDocsArchived) {
+    docs = await MongoManager.getNonDeletedArchivedProjectDocs(projectId)
+  } else {
+    docs = await MongoManager.getArchivedProjectDocs(projectId)
+  }
   if (!docs) {
     throw new Errors.NotFoundError(`No docs for project ${projectId}`)
   }

--- a/app/js/MongoManager.js
+++ b/app/js/MongoManager.js
@@ -53,6 +53,15 @@ module.exports = MongoManager = {
     db.docs.find(query).toArray(callback)
   },
 
+  getNonDeletedArchivedProjectDocs(project_id, callback) {
+    const query = {
+      project_id: ObjectId(project_id.toString()),
+      deleted: { $ne: true },
+      inS3: true
+    }
+    db.docs.find(query).toArray(callback)
+  },
+
   upsertIntoDocCollection(project_id, doc_id, updates, callback) {
     const update = {
       $set: updates,

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -23,6 +23,8 @@ const Settings = {
 
   docstore: {
     archiveOnSoftDelete: process.env.ARCHIVE_ON_SOFT_DELETE === 'true',
+    keepSoftDeletedDocsArchived:
+      process.env.KEEP_SOFT_DELETED_DOCS_ARCHIVED === 'true',
 
     backend: process.env.BACKEND || 's3',
     healthCheck: {


### PR DESCRIPTION

### Description

For https://github.com/overleaf/issues/issues/3733
Chained onto https://github.com/overleaf/docstore/pull/85 (otherwise conflicting)

As per https://github.com/overleaf/issues/issues/3733#issuecomment-754060726 it should be safe to restore non deleted docs only.
This PR is putting a changed mongo query behind a feature flag.

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/3733

### Review

The extended test suite in the acceptance tests manipulated the doc in a before handler, in order to adjust the un-archiving with the changed feature flag this needs changing into a beforeEach handler in order to get a new doc per test case.

#### Potential Impact

Low. New logic is behind a feature flag.

#### Manual Testing Performed

- added acceptance test
