### PR TITLE
[misc] add a new endpoint for querying the deleted status of a doc

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,6 +46,7 @@ Metrics.injectMetricsRoute(app)
 app.get('/project/:project_id/doc', HttpController.getAllDocs)
 app.get('/project/:project_id/ranges', HttpController.getAllRanges)
 app.get('/project/:project_id/doc/:doc_id', HttpController.getDoc)
+app.get('/project/:project_id/doc/:doc_id/deleted', HttpController.isDocDeleted)
 app.get('/project/:project_id/doc/:doc_id/raw', HttpController.getRawDoc)
 // Add 64kb overhead for the JSON encoding, and double the size to allow for ranges in the json payload
 app.post(

--- a/app/js/DocManager.js
+++ b/app/js/DocManager.js
@@ -90,6 +90,24 @@ module.exports = DocManager = {
     )
   },
 
+  isDocDeleted(projectId, docId, callback) {
+    MongoManager.findDoc(projectId, docId, { deleted: true }, function (
+      err,
+      doc
+    ) {
+      if (err) {
+        return callback(err)
+      }
+      if (!doc) {
+        return callback(
+          new Errors.NotFoundError(`No such project/doc: ${projectId}/${docId}`)
+        )
+      }
+      // `doc.deleted` is `undefined` for non deleted docs
+      callback(null, Boolean(doc.deleted))
+    })
+  },
+
   getFullDoc(project_id, doc_id, callback) {
     if (callback == null) {
       callback = function (err, doc) {}

--- a/app/js/HttpController.js
+++ b/app/js/HttpController.js
@@ -44,6 +44,16 @@ module.exports = HttpController = {
     })
   },
 
+  isDocDeleted(req, res, next) {
+    const { doc_id: docId, project_id: projectId } = req.params
+    DocManager.isDocDeleted(projectId, docId, function (error, deleted) {
+      if (error) {
+        return next(error)
+      }
+      res.json({ deleted })
+    })
+  },
+
   getRawDoc(req, res, next) {
     if (next == null) {
       next = function (error) {}

--- a/test/acceptance/js/helpers/DocstoreClient.js
+++ b/test/acceptance/js/helpers/DocstoreClient.js
@@ -60,6 +60,16 @@ module.exports = DocstoreClient = {
     )
   },
 
+  isDocDeleted(project_id, doc_id, callback) {
+    request.get(
+      {
+        url: `http://localhost:${settings.internal.docstore.port}/project/${project_id}/doc/${doc_id}/deleted`,
+        json: true
+      },
+      callback
+    )
+  },
+
   getAllDocs(project_id, callback) {
     if (callback == null) {
       callback = function (error, res, body) {}


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/3920

`/project/:project_id/doc/:doc_id/deleted` responds with:

- 404: the doc does not exist
- 200 and body `{"deleted":true}`: doc exists and is deleted
- 200 and body `{"deleted":false}`: doc exists and is not deleted


#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/3920

#### Potential Impact

Low. New endpoint.

#### Manual Testing Performed

-  see added acceptance tests -- includes cross project access