### PR TITLE
[MongoManager] store doc details on delete

### DIFF
--- a/app/js/DocManager.js
+++ b/app/js/DocManager.js
@@ -287,7 +287,7 @@ module.exports = DocManager = {
     )
   },
 
-  deleteDoc(project_id, doc_id, callback) {
+  deleteDoc(project_id, doc_id, name, callback) {
     if (callback == null) {
       callback = function (error) {}
     }
@@ -318,7 +318,7 @@ module.exports = DocManager = {
         })
       }
 
-      return MongoManager.markDocAsDeleted(project_id, doc_id, callback)
+      MongoManager.markDocAsDeleted(project_id, doc_id, name, callback)
     })
   }
 }

--- a/app/js/HttpController.js
+++ b/app/js/HttpController.js
@@ -179,8 +179,9 @@ module.exports = HttpController = {
     }
     const { project_id } = req.params
     const { doc_id } = req.params
+    const { name } = req.query
     logger.log({ project_id, doc_id }, 'deleting doc')
-    return DocManager.deleteDoc(project_id, doc_id, function (error) {
+    DocManager.deleteDoc(project_id, doc_id, name, function (error) {
       if (error != null) {
         return next(error)
       }

--- a/app/js/MongoManager.js
+++ b/app/js/MongoManager.js
@@ -82,7 +82,7 @@ module.exports = MongoManager = {
   },
 
   markDocAsDeleted(project_id, doc_id, name, callback) {
-    const update = { deleted: true }
+    const update = { deleted: true, deletedAt: new Date() }
     if (name) {
       update.name = name
     }

--- a/app/js/MongoManager.js
+++ b/app/js/MongoManager.js
@@ -81,14 +81,18 @@ module.exports = MongoManager = {
     )
   },
 
-  markDocAsDeleted(project_id, doc_id, callback) {
+  markDocAsDeleted(project_id, doc_id, name, callback) {
+    const update = { deleted: true }
+    if (name) {
+      update.name = name
+    }
     db.docs.updateOne(
       {
         _id: ObjectId(doc_id),
         project_id: ObjectId(project_id)
       },
       {
-        $set: { deleted: true }
+        $set: update
       },
       callback
     )

--- a/test/acceptance/js/DeletingDocsTests.js
+++ b/test/acceptance/js/DeletingDocsTests.js
@@ -104,6 +104,39 @@ describe('Deleting a doc', function () {
         })
       }, 1000)
     })
+
+    describe('deleting a doc twice', function () {
+      beforeEach('get doc before 2nd DELETE request', function (done) {
+        db.docs.find({ _id: this.doc_id }).toArray((error, docs) => {
+          if (error) return done(error)
+          this.docBefore = docs[0]
+          if (!this.docBefore) return done(new Error('doc not found'))
+          done()
+        })
+      })
+
+      beforeEach('perform 2nd DELETE request', function (done) {
+        DocstoreClient.deleteDoc(this.project_id, this.doc_id, (error, res) => {
+          this.res1 = res
+          done(error)
+        })
+      })
+
+      it('should return success', function () {
+        expect(this.res1.statusCode).to.equal(204)
+      })
+
+      it('should not alter the previous doc state', function (done) {
+        db.docs.find({ _id: this.doc_id }).toArray((error, docs) => {
+          if (error) return done(error)
+          const docAfter = docs[0]
+          if (!docAfter) return done(new Error('doc not found'))
+
+          expect(docAfter).to.deep.equal(this.docBefore)
+          done()
+        })
+      })
+    })
   })
 
   describe('when providing a doc name in the delete request', function () {

--- a/test/acceptance/js/DeletingDocsTests.js
+++ b/test/acceptance/js/DeletingDocsTests.js
@@ -106,6 +106,39 @@ describe('Deleting a doc', function () {
     })
   })
 
+  describe('when providing a doc name in the delete request', function () {
+    beforeEach(function (done) {
+      DocstoreClient.deleteDocWithName(
+        this.project_id,
+        this.doc_id,
+        'wombat.tex',
+        done
+      )
+    })
+
+    it('should insert the doc name into the docs collection', function (done) {
+      db.docs.find({ _id: this.doc_id }).toArray((error, docs) => {
+        if (error) return done(error)
+        expect(docs[0].name).to.equal('wombat.tex')
+        done()
+      })
+    })
+  })
+
+  describe('when providing no doc name in the delete request', function () {
+    beforeEach(function (done) {
+      DocstoreClient.deleteDocWithName(this.project_id, this.doc_id, '', done)
+    })
+
+    it('should not populate the doc name the docs collection', function (done) {
+      db.docs.find({ _id: this.doc_id }).toArray((error, docs) => {
+        if (error) return done(error)
+        expect(docs[0]).to.not.have.property('name')
+        done()
+      })
+    })
+  })
+
   describe('when archiveOnSoftDelete is enabled', function () {
     let archiveOnSoftDelete
     beforeEach(function overwriteSetting() {

--- a/test/acceptance/js/DeletingDocsTests.js
+++ b/test/acceptance/js/DeletingDocsTests.js
@@ -60,10 +60,12 @@ describe('Deleting a doc', function () {
 
   describe('when the doc exists', function () {
     beforeEach(function (done) {
+      this.dateBefore = new Date()
       return DocstoreClient.deleteDoc(
         this.project_id,
         this.doc_id,
         (error, res, doc) => {
+          this.dateAfter = new Date()
           this.res = res
           return done()
         }
@@ -92,6 +94,9 @@ describe('Deleting a doc', function () {
         docs[0]._id.should.deep.equal(this.doc_id)
         docs[0].lines.should.deep.equal(this.lines)
         docs[0].deleted.should.equal(true)
+        expect(docs[0])
+          .to.have.property('deletedAt')
+          .and.to.be.within(this.dateBefore, this.dateAfter)
         return done()
       })
     })

--- a/test/acceptance/js/helpers/DocstoreClient.js
+++ b/test/acceptance/js/helpers/DocstoreClient.js
@@ -116,12 +116,14 @@ module.exports = DocstoreClient = {
   },
 
   deleteDoc(project_id, doc_id, callback) {
-    if (callback == null) {
-      callback = function (error, res, body) {}
-    }
-    return request.del(
+    this.deleteDocWithName(project_id, doc_id, 'main.tex', callback)
+  },
+
+  deleteDocWithName(project_id, doc_id, name, callback) {
+    request.del(
       {
-        url: `http://localhost:${settings.internal.docstore.port}/project/${project_id}/doc/${doc_id}`
+        url: `http://localhost:${settings.internal.docstore.port}/project/${project_id}/doc/${doc_id}`,
+        qs: { name }
       },
       callback
     )

--- a/test/unit/js/DocManagerTests.js
+++ b/test/unit/js/DocManagerTests.js
@@ -437,6 +437,7 @@ describe('DocManager', function () {
         return this.DocManager.deleteDoc(
           this.project_id,
           this.doc_id,
+          'tomato.tex',
           this.callback
         )
       })
@@ -449,7 +450,7 @@ describe('DocManager', function () {
 
       it('should mark doc as deleted', function () {
         return this.MongoManager.markDocAsDeleted
-          .calledWith(this.project_id, this.doc_id)
+          .calledWith(this.project_id, this.doc_id, 'tomato.tex')
           .should.equal(true)
       })
 
@@ -528,6 +529,7 @@ describe('DocManager', function () {
         return this.DocManager.deleteDoc(
           this.project_id,
           this.doc_id,
+          'blue.tex',
           this.callback
         )
       })

--- a/test/unit/js/HttpControllerTests.js
+++ b/test/unit/js/HttpControllerTests.js
@@ -441,18 +441,30 @@ describe('HttpController', function () {
         project_id: this.project_id,
         doc_id: this.doc_id
       }
-      this.DocManager.deleteDoc = sinon.stub().callsArg(2)
+      this.DocManager.deleteDoc = sinon.stub().yields()
       return this.HttpController.deleteDoc(this.req, this.res, this.next)
     })
 
     it('should delete the document', function () {
       return this.DocManager.deleteDoc
-        .calledWith(this.project_id, this.doc_id)
+        .calledWith(this.project_id, this.doc_id, undefined)
         .should.equal(true)
     })
 
-    return it('should return a 204 (No Content)', function () {
+    it('should return a 204 (No Content)', function () {
       return this.res.sendStatus.calledWith(204).should.equal(true)
+    })
+
+    describe('with a name in the query', function () {
+      beforeEach(function () {
+        this.req.query = { name: 'green.tex' }
+        this.HttpController.deleteDoc(this.req, this.res, this.next)
+      })
+      it('should forward the name', function () {
+        this.DocManager.deleteDoc
+          .calledWith(this.project_id, this.doc_id, 'green.tex')
+          .should.equal(true)
+      })
     })
   })
 

--- a/test/unit/js/MongoManagerTests.js
+++ b/test/unit/js/MongoManagerTests.js
@@ -190,17 +190,22 @@ describe('MongoManager', function () {
     })
 
     it('should process the update', function (done) {
+      this.dateBefore = new Date()
       return this.MongoManager.markDocAsDeleted(
         this.project_id,
         this.doc_id,
         undefined,
         (err) => {
+          this.dateAfter = new Date()
           const args = this.db.docs.updateOne.args[0]
           assert.deepEqual(args[0], {
             _id: ObjectId(this.doc_id),
             project_id: ObjectId(this.project_id)
           })
           assert.equal(args[1].$set.deleted, true)
+          expect(args[1].$set)
+            .to.have.property('deletedAt')
+            .and.to.be.within(this.dateBefore, this.dateAfter)
           return done()
         }
       )


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/3733

This PR is preparing docstore for persisting doc meta data on deletion.
- doc name for later querying them again
- deletedAt data for documentation of operations only

Web will soon start sending the doc name as part of the delete request, so the name field is optional at this time.

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/3733

### Review

To protect the deletedAt date, I changed the delete process to be idempotent.

#### Potential Impact

Medium, 

#### Manual Testing Performed

- see added acceptance and unit
- create a project
- create a new doc
- delete the doc
- reload the editor and do not see the doc