### PR TITLE
[misc] add a new endpoint for getting deleted docs

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,6 +43,7 @@ app.param('doc_id', function (req, res, next, docId) {
 
 Metrics.injectMetricsRoute(app)
 
+app.get('/project/:project_id/doc-deleted', HttpController.getAllDeletedDocs)
 app.get('/project/:project_id/doc', HttpController.getAllDocs)
 app.get('/project/:project_id/ranges', HttpController.getAllRanges)
 app.get('/project/:project_id/doc/:doc_id', HttpController.getDoc)

--- a/app/js/DocManager.js
+++ b/app/js/DocManager.js
@@ -150,6 +150,10 @@ module.exports = DocManager = {
     )
   },
 
+  getAllDeletedDocs(project_id, filter, callback) {
+    MongoManager.getProjectsDeletedDocs(project_id, filter, callback)
+  },
+
   getAllNonDeletedDocs(project_id, filter, callback) {
     if (callback == null) {
       callback = function (error, docs) {}

--- a/app/js/HttpController.js
+++ b/app/js/HttpController.js
@@ -95,6 +95,24 @@ module.exports = HttpController = {
     )
   },
 
+  getAllDeletedDocs(req, res, next) {
+    const { project_id } = req.params
+    logger.log({ project_id }, 'getting all deleted docs')
+    DocManager.getAllDeletedDocs(project_id, { name: true }, function (
+      error,
+      docs
+    ) {
+      if (error) {
+        return next(error)
+      }
+      res.json(
+        docs.map((doc) => {
+          return { _id: doc._id.toString(), name: doc.name }
+        })
+      )
+    })
+  },
+
   getAllRanges(req, res, next) {
     if (next == null) {
       next = function (error) {}

--- a/app/js/MongoManager.js
+++ b/app/js/MongoManager.js
@@ -14,6 +14,7 @@ let MongoManager
 const { db, ObjectId } = require('./mongodb')
 const logger = require('logger-sharelatex')
 const metrics = require('@overleaf/metrics')
+const Settings = require('settings-sharelatex')
 const { promisify } = require('util')
 
 module.exports = MongoManager = {
@@ -31,6 +32,24 @@ module.exports = MongoManager = {
       },
       callback
     )
+  },
+
+  getProjectsDeletedDocs(project_id, filter, callback) {
+    db.docs
+      .find(
+        {
+          project_id: ObjectId(project_id.toString()),
+          deleted: true,
+          // TODO(das7pad): remove name filter after back filling data
+          name: { $exists: true }
+        },
+        {
+          projection: filter,
+          sort: { deletedAt: -1 },
+          limit: Settings.max_deleted_docs
+        }
+      )
+      .toArray(callback)
   },
 
   getProjectsDocs(project_id, options, filter, callback) {

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -38,6 +38,8 @@ const Settings = {
     }
   },
 
+  max_deleted_docs: parseInt(process.env.MAX_DELETED_DOCS, 10) || 2000,
+
   max_doc_length: parseInt(process.env.MAX_DOC_LENGTH) || 2 * 1024 * 1024 // 2mb
 }
 

--- a/test/acceptance/js/helpers/DocstoreClient.js
+++ b/test/acceptance/js/helpers/DocstoreClient.js
@@ -85,6 +85,22 @@ module.exports = DocstoreClient = {
     )
   },
 
+  getAllDeletedDocs(project_id, callback) {
+    request.get(
+      {
+        url: `http://localhost:${settings.internal.docstore.port}/project/${project_id}/doc-deleted`,
+        json: true
+      },
+      (error, res, body) => {
+        if (error) return callback(error)
+        if (res.statusCode !== 200) {
+          return callback(new Error('unexpected statusCode'))
+        }
+        callback(null, body)
+      }
+    )
+  },
+
   getAllRanges(project_id, callback) {
     if (callback == null) {
       callback = function (error, res, body) {}

--- a/test/unit/js/MongoManagerTests.js
+++ b/test/unit/js/MongoManagerTests.js
@@ -28,7 +28,8 @@ describe('MongoManager', function () {
           ObjectId
         },
         '@overleaf/metrics': { timeAsyncMethod: sinon.stub() },
-        'logger-sharelatex': { log() {} }
+        'logger-sharelatex': { log() {} },
+        'settings-sharelatex': { max_deleted_docs: 42 }
       },
       globals: {
         console
@@ -145,6 +146,50 @@ describe('MongoManager', function () {
           .calledWith(null, [this.doc, this.doc3, this.doc4])
           .should.equal(true)
       })
+    })
+  })
+
+  describe('getProjectsDeletedDocs', function () {
+    beforeEach(function (done) {
+      this.filter = { name: true }
+      this.doc1 = { _id: '1', name: 'mock-doc1.tex' }
+      this.doc2 = { _id: '2', name: 'mock-doc2.tex' }
+      this.doc3 = { _id: '3', name: 'mock-doc3.tex' }
+      this.db.docs.find = sinon.stub().returns({
+        toArray: sinon.stub().yields(null, [this.doc1, this.doc2, this.doc3])
+      })
+      this.callback.callsFake(done)
+      this.MongoManager.getProjectsDeletedDocs(
+        this.project_id,
+        this.filter,
+        this.callback
+      )
+    })
+
+    it('should find the deleted docs via the project_id', function () {
+      this.db.docs.find
+        .calledWith({
+          project_id: ObjectId(this.project_id),
+          deleted: true,
+          name: { $exists: true }
+        })
+        .should.equal(true)
+    })
+
+    it('should filter, sort by deletedAt and limit', function () {
+      this.db.docs.find
+        .calledWith(sinon.match.any, {
+          projection: this.filter,
+          sort: { deletedAt: -1 },
+          limit: 42
+        })
+        .should.equal(true)
+    })
+
+    it('should call the callback with the docs', function () {
+      this.callback
+        .calledWith(null, [this.doc1, this.doc2, this.doc3])
+        .should.equal(true)
     })
   })
 


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/3733
Chained onto https://github.com/overleaf/docstore/pull/91

This PR is implementing a new endpoint for getting a projects deleted docs.
Specifically we are emitting their doc name only.

The mongo query sorts by deletion date and limit the response to 2000 items (has a config option).
The data will be queried by the frontend -> joinProject real-time -> web-api -> docstore.
The frontend uses this data for the history pane (displayed in a list for restoring in projects with old-history) and also in the file-tree (I did not investigate this usage).

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/3733
Chained onto https://github.com/overleaf/docstore/pull/91

### Review

The doc meta is incomplete at this time -- not all deleted docs have their name in the docs collection -- until after a script back fills the data from the projects collection. This is noted in a TODO item.

The mongo query uses the index on the project id, which should be efficient enough for querying the data.

<details>

```
> db.docs.find({ project_id: ObjectId("602650c7080b1879d43774fd"), deleted: true, name: { $exists: true } }).explain()
{
        "queryPlanner" : {
                "plannerVersion" : 1,
                "namespace" : "sharelatex.docs",
                "indexFilterSet" : false,
                "parsedQuery" : {
                        "$and" : [
                                {
                                        "deleted" : {
                                                "$eq" : true
                                        }
                                },
                                {
                                        "project_id" : {
                                                "$eq" : ObjectId("602650c7080b1879d43774fd")
                                        }
                                },
                                {
                                        "name" : {
                                                "$exists" : true
                                        }
                                }
                        ]
                },
                "winningPlan" : {
                        "stage" : "FETCH",
                        "filter" : {
                                "$and" : [
                                        {
                                                "deleted" : {
                                                        "$eq" : true
                                                }
                                        },
                                        {
                                                "name" : {
                                                        "$exists" : true
                                                }
                                        }
                                ]
                        },
                        "inputStage" : {
                                "stage" : "IXSCAN",
                                "keyPattern" : {
                                        "project_id" : 1
                                },
                                "indexName" : "project_id_1",
                                "isMultiKey" : false,
                                "multiKeyPaths" : {
                                        "project_id" : [ ]
                                },
                                "isUnique" : false,
                                "isSparse" : false,
                                "isPartial" : false,
                                "indexVersion" : 1,
                                "direction" : "forward",
                                "indexBounds" : {
                                        "project_id" : [
                                                "[ObjectId('602650c7080b1879d43774fd'), ObjectId('602650c7080b1879d43774fd')]"
                                        ]
                                }
                        }
                },
                "rejectedPlans" : [ ... ]
        },
        "ok" : 1
}
```
</details>

#### Potential Impact

Low.

#### Manual Testing Performed

- see added acceptance tests
- use branch of future web PR, emit deletedDocs from docstore+web in joinProject response, matches