### PR TITLE
[misc] bump the version of the metrics module to 3.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -239,9 +239,9 @@
           "integrity": "sha512-d4VSA86eL/AFTe5xtyZX+ePUjE8dIFu2T8zmdeNBSa5/kNgXPCx/o/wbFNHAGLJdGnk1vddRuMESD9HbOC8irw=="
         },
         "acorn": {
-          "version": "8.0.4",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.4.tgz",
-          "integrity": "sha512-XNP0PqF1XD19ZlLKvB7cMmnZswW4C/03pRHgirB30uSJTaS3A3V1/P4sS3HPvFmjoriPCJQs+JDSbm4bL1TxGQ=="
+          "version": "8.0.5",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.5.tgz",
+          "integrity": "sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg=="
         },
         "bignumber.js": {
           "version": "9.0.1",
@@ -260,9 +260,9 @@
           }
         },
         "gaxios": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.0.1.tgz",
-          "integrity": "sha512-jOin8xRZ/UytQeBpSXFqIzqU7Fi5TqgPNLlUsSB8kjJ76+FiGBfImF8KJu++c6J4jOldfJUtt0YmkRj2ZpSHTQ==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.1.0.tgz",
+          "integrity": "sha512-vb0to8xzGnA2qcgywAjtshOKKVDf2eQhJoiL6fHhgW5tVN7wNk7egnYIO9zotfn3lQ3De1VPdf7V5/BWfCtCmg==",
           "requires": {
             "abort-controller": "^3.0.0",
             "extend": "^3.0.2",
@@ -281,9 +281,9 @@
           }
         },
         "google-auth-library": {
-          "version": "6.1.3",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.3.tgz",
-          "integrity": "sha512-m9mwvY3GWbr7ZYEbl61isWmk+fvTmOt0YNUfPOUY2VH8K5pZlAIWJjxEi0PqR3OjMretyiQLI6GURMrPSwHQ2g==",
+          "version": "6.1.6",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
+          "integrity": "sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==",
           "requires": {
             "arrify": "^2.0.0",
             "base64-js": "^1.3.0",
@@ -305,14 +305,13 @@
           }
         },
         "gtoken": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.1.0.tgz",
-          "integrity": "sha512-4d8N6Lk8TEAHl9vVoRVMh9BNOKWVgl2DdNtr3428O75r3QFrF/a5MMu851VmK0AA8+iSvbwRv69k5XnMLURGhg==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.1.tgz",
+          "integrity": "sha512-OY0BfPKe3QnMsY9MzTHTSKn+Vl2l1CcLe6BwDEQj00mbbkl5nyQ/7EUREstg4fQNZ8iYE7br4JJ7TdKeDOPWmw==",
           "requires": {
             "gaxios": "^4.0.0",
             "google-p12-pem": "^3.0.3",
-            "jws": "^4.0.0",
-            "mime": "^2.2.0"
+            "jws": "^4.0.0"
           }
         },
         "json-bigint": {
@@ -355,9 +354,12 @@
           }
         },
         "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         },
         "teeny-request": {
           "version": "7.0.1",
@@ -372,9 +374,9 @@
           }
         },
         "uuid": {
-          "version": "8.3.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-          "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         },
         "yallist": {
           "version": "4.0.0",
@@ -513,9 +515,9 @@
           }
         },
         "gaxios": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.0.1.tgz",
-          "integrity": "sha512-jOin8xRZ/UytQeBpSXFqIzqU7Fi5TqgPNLlUsSB8kjJ76+FiGBfImF8KJu++c6J4jOldfJUtt0YmkRj2ZpSHTQ==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.1.0.tgz",
+          "integrity": "sha512-vb0to8xzGnA2qcgywAjtshOKKVDf2eQhJoiL6fHhgW5tVN7wNk7egnYIO9zotfn3lQ3De1VPdf7V5/BWfCtCmg==",
           "requires": {
             "abort-controller": "^3.0.0",
             "extend": "^3.0.2",
@@ -534,9 +536,9 @@
           }
         },
         "google-auth-library": {
-          "version": "6.1.3",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.3.tgz",
-          "integrity": "sha512-m9mwvY3GWbr7ZYEbl61isWmk+fvTmOt0YNUfPOUY2VH8K5pZlAIWJjxEi0PqR3OjMretyiQLI6GURMrPSwHQ2g==",
+          "version": "6.1.6",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
+          "integrity": "sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==",
           "requires": {
             "arrify": "^2.0.0",
             "base64-js": "^1.3.0",
@@ -558,14 +560,13 @@
           }
         },
         "gtoken": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.1.0.tgz",
-          "integrity": "sha512-4d8N6Lk8TEAHl9vVoRVMh9BNOKWVgl2DdNtr3428O75r3QFrF/a5MMu851VmK0AA8+iSvbwRv69k5XnMLURGhg==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.1.tgz",
+          "integrity": "sha512-OY0BfPKe3QnMsY9MzTHTSKn+Vl2l1CcLe6BwDEQj00mbbkl5nyQ/7EUREstg4fQNZ8iYE7br4JJ7TdKeDOPWmw==",
           "requires": {
             "gaxios": "^4.0.0",
             "google-p12-pem": "^3.0.3",
-            "jws": "^4.0.0",
-            "mime": "^2.2.0"
+            "jws": "^4.0.0"
           }
         },
         "json-bigint": {
@@ -600,9 +601,12 @@
           }
         },
         "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         },
         "teeny-request": {
           "version": "7.0.1",
@@ -617,9 +621,9 @@
           }
         },
         "uuid": {
-          "version": "8.3.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-          "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         },
         "yallist": {
           "version": "4.0.0",
@@ -773,9 +777,9 @@
       }
     },
     "@google-cloud/trace-agent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/trace-agent/-/trace-agent-5.1.1.tgz",
-      "integrity": "sha512-YTcK0RLN90pLCprg0XC8uV4oAVd79vsXhkcxmEVwiOOYjUDvSrAhb7y/0SY606zgfhJHmUTNb/fZSWEtZP/slQ==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/trace-agent/-/trace-agent-5.1.3.tgz",
+      "integrity": "sha512-f+5DX7n6QpDlHA+4kr81z69SLAdrlvd9T8skqCMgnYvtXx14AwzXZyzEDf3jppOYzYoqPPJv8XYiyYHHmYD0BA==",
       "requires": {
         "@google-cloud/common": "^3.0.0",
         "@opencensus/propagation-stackdriver": "0.0.22",
@@ -784,7 +788,7 @@
         "continuation-local-storage": "^3.2.1",
         "extend": "^3.0.2",
         "gcp-metadata": "^4.0.0",
-        "google-auth-library": "^6.0.0",
+        "google-auth-library": "^7.0.0",
         "hex2dec": "^1.0.1",
         "is": "^3.2.0",
         "methods": "^1.1.1",
@@ -812,9 +816,9 @@
           },
           "dependencies": {
             "google-auth-library": {
-              "version": "6.1.3",
-              "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.3.tgz",
-              "integrity": "sha512-m9mwvY3GWbr7ZYEbl61isWmk+fvTmOt0YNUfPOUY2VH8K5pZlAIWJjxEi0PqR3OjMretyiQLI6GURMrPSwHQ2g==",
+              "version": "6.1.6",
+              "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
+              "integrity": "sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==",
               "requires": {
                 "arrify": "^2.0.0",
                 "base64-js": "^1.3.0",
@@ -878,9 +882,9 @@
           }
         },
         "gaxios": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.0.1.tgz",
-          "integrity": "sha512-jOin8xRZ/UytQeBpSXFqIzqU7Fi5TqgPNLlUsSB8kjJ76+FiGBfImF8KJu++c6J4jOldfJUtt0YmkRj2ZpSHTQ==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.1.0.tgz",
+          "integrity": "sha512-vb0to8xzGnA2qcgywAjtshOKKVDf2eQhJoiL6fHhgW5tVN7wNk7egnYIO9zotfn3lQ3De1VPdf7V5/BWfCtCmg==",
           "requires": {
             "abort-controller": "^3.0.0",
             "extend": "^3.0.2",
@@ -898,6 +902,22 @@
             "json-bigint": "^1.0.0"
           }
         },
+        "google-auth-library": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.0.2.tgz",
+          "integrity": "sha512-vjyNZR3pDLC0u7GHLfj+Hw9tGprrJwoMwkYGqURCXYITjCrP9HprOyxVV+KekdLgATtWGuDkQG2MTh0qpUPUgg==",
+          "requires": {
+            "arrify": "^2.0.0",
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "fast-text-encoding": "^1.0.0",
+            "gaxios": "^4.0.0",
+            "gcp-metadata": "^4.2.0",
+            "gtoken": "^5.0.4",
+            "jws": "^4.0.0",
+            "lru-cache": "^6.0.0"
+          }
+        },
         "google-p12-pem": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
@@ -907,14 +927,13 @@
           }
         },
         "gtoken": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.1.0.tgz",
-          "integrity": "sha512-4d8N6Lk8TEAHl9vVoRVMh9BNOKWVgl2DdNtr3428O75r3QFrF/a5MMu851VmK0AA8+iSvbwRv69k5XnMLURGhg==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.1.tgz",
+          "integrity": "sha512-OY0BfPKe3QnMsY9MzTHTSKn+Vl2l1CcLe6BwDEQj00mbbkl5nyQ/7EUREstg4fQNZ8iYE7br4JJ7TdKeDOPWmw==",
           "requires": {
             "gaxios": "^4.0.0",
             "google-p12-pem": "^3.0.3",
-            "jws": "^4.0.0",
-            "mime": "^2.2.0"
+            "jws": "^4.0.0"
           }
         },
         "json-bigint": {
@@ -949,9 +968,12 @@
           }
         },
         "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         },
         "teeny-request": {
           "version": "7.0.1",
@@ -966,9 +988,9 @@
           }
         },
         "uuid": {
-          "version": "8.3.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-          "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         },
         "yallist": {
           "version": "4.0.0",
@@ -1031,9 +1053,9 @@
       }
     },
     "@overleaf/metrics": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@overleaf/metrics/-/metrics-3.4.1.tgz",
-      "integrity": "sha512-OgjlzuC+2gPdIEDHhmd9LDMu01tk1ln0cJhw1727BZ+Wgf2Z1hjuHRt4JeCkf+PFTHwJutVYT8v6IGPpNEPtbg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@overleaf/metrics/-/metrics-3.5.1.tgz",
+      "integrity": "sha512-RLHxkMF7Y3725L3QwXo9cIn2gGobsMYUGuxKxg7PVMrPTMsomHEMeG7StOxCO7ML1Z/BwB/9nsVYNrsRdAJtKg==",
       "requires": {
         "@google-cloud/debug-agent": "^5.1.2",
         "@google-cloud/profiler": "^4.0.3",
@@ -1658,7 +1680,7 @@
     "bintrees": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
-      "integrity": "sha512-tbaUB1QpTIj4cKY8c1rvNAvEQXA+ekzHmbe4jzNfW3QWsF9GnnP/BRWyl6/qqS53heoYJ93naaFcm/jooONH8g=="
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
     },
     "bl": {
       "version": "2.2.1",
@@ -1742,9 +1764,9 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "builtin-modules": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
-      "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+      "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA=="
     },
     "bunyan": {
       "version": "1.8.14",
@@ -2244,9 +2266,9 @@
       }
     },
     "delay": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/delay/-/delay-4.4.0.tgz",
-      "integrity": "sha512-txgOrJu3OdtOfTiEOT2e76dJVfG/1dz2NZ4F0Pyt4UGZJryssMRp5vdM5wQoLwSOBNdrJv3F9PAhp/heqd7vrA=="
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-4.4.1.tgz",
+      "integrity": "sha512-aL3AhqtfhOlT/3ai6sWXeqwnw63ATNpnUiN4HL7x9q+My5QtHlO3OIkasmug9LKzpheLdmUKGRKnYXYAS7FQkQ=="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -3061,7 +3083,7 @@
     "findit2": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/findit2/-/findit2-2.2.3.tgz",
-      "integrity": "sha512-lg/Moejf4qXovVutL0Lz4IsaPoNYMuxt4PA0nGqFxnJ1CTTGGlEO2wKgoDpwknhvZ8k4Q2F+eesgkLbG2Mxfog=="
+      "integrity": "sha1-WKRmaX34piBc39vzlVNri9d3pfY="
     },
     "flat": {
       "version": "4.1.0",
@@ -3845,9 +3867,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
-      "integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -4589,7 +4611,7 @@
     "module-details-from-path": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
-      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
+      "integrity": "sha1-EUyUlnPiqKNenTV4hSeqN7Z52is="
     },
     "moment": {
       "version": "2.24.0",
@@ -4650,9 +4672,9 @@
       "optional": true
     },
     "needle": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.2.tgz",
-      "integrity": "sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.6.0.tgz",
+      "integrity": "sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==",
       "requires": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -4668,9 +4690,9 @@
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "sax": {
           "version": "1.2.4",
@@ -6136,9 +6158,9 @@
       "dev": true
     },
     "require-in-the-middle": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.0.3.tgz",
-      "integrity": "sha512-p/ICV8uMlqC4tjOYabLMxAWCIKa0YUQgZZ6KDM0xgXJNgdGQ1WmL2A07TwmrZw+wi6ITUFKzH5v3n+ENEyXVkA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.1.0.tgz",
+      "integrity": "sha512-M2rLKVupQfJ5lf9OvqFGIT+9iVLnTmjgbOmpil12hiSQNn5zJTKGPoIisETNjfK+09vP3rpm1zJajmErpr2sEQ==",
       "requires": {
         "debug": "^4.1.1",
         "module-details-from-path": "^1.0.3",
@@ -6159,11 +6181,11 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "resolve": {
-          "version": "1.19.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
           "requires": {
-            "is-core-module": "^2.1.0",
+            "is-core-module": "^2.2.0",
             "path-parse": "^1.0.6"
           }
         }
@@ -6208,7 +6230,7 @@
     "resolve-from": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha512-qpFcKaXsq8+oRoLilkwyc7zHGF5i9Q2/25NIgLQQ/+VVv9rU4qvr6nXVAw1DsnXJyQkZsR4Ytfbtg5ehfcUssQ=="
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
     },
     "restore-cursor": {
       "version": "3.1.0",
@@ -6513,7 +6535,7 @@
     "sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
-      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
       "optional": true,
       "requires": {
         "memory-pager": "^1.0.2"
@@ -6741,7 +6763,7 @@
     "stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
-      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="
+      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
     },
     "supports-color": {
       "version": "6.0.0",
@@ -6824,7 +6846,7 @@
     "tdigest": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
-      "integrity": "sha512-CXcDY/NIgIbKZPx5H4JJNpq6JwJhU5Z4+yWj4ZghDc7/9nVajiRlPPyMXRePPPlBfcayUqtoCXjo7/Hm82ecUA==",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
       "requires": {
         "bintrees": "1.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "format:fix": "node_modules/.bin/prettier-eslint $PWD'/**/*.js' --write"
   },
   "dependencies": {
-    "@overleaf/metrics": "^3.4.1",
+    "@overleaf/metrics": "^3.5.1",
     "@overleaf/object-persistor": "https://github.com/overleaf/object-persistor/archive/4ca62157a2beb747e9a56da3ce1569124b90378a.tar.gz",
     "async": "^2.6.3",
     "body-parser": "^1.19.0",


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/3764

- 3.5.1

  - drop background process

- 3.5.0

  - decaf cleanup
  - add support for swagger-tools router

####

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/3764

#### Potential Impact

High. Incomplete metrics collection.

#### Manual testing performed

- create a new project
- open a project in the editor
- make changes to a document, reload the editor to check persistence
- compile a project
- open the history tab in the editor
- repeat testing with legacy history service
- all services seem to be running fine in the dev-env
- request all the `/metrics` endpoints and see many metric lines each

    ```
    dev-environment$ grep -e 127.0.0.1:3 -e 127.0.0.1:40 docker-compose.yml | sed -E 's/.+- (.+):(.+):(.+)/\1:\2/' | xargs -I % sh -c 'echo -n "%: lines=" && curl %/metrics -s | wc -l'
    127.0.0.1:3010: lines=116
    127.0.0.1:3016: lines=242
    127.0.0.1:3003: lines=510
    127.0.0.1:3009: lines=212
    127.0.0.1:3022: lines=141
    127.0.0.1:3026: lines=224
    127.0.0.1:3036: lines=128
    127.0.0.1:3042: lines=161
    127.0.0.1:3015: lines=190
    127.0.0.1:3054: lines=405
    127.0.0.1:4000: lines=800
    127.0.0.1:3809: lines=10   <- 404 from webpack, which is fine
    127.0.0.1:3013: lines=306
    127.0.0.1:3005: lines=162
    127.0.0.1:3007: lines=116
    127.0.0.1:3050: lines=132
    127.0.0.1:3046: lines=153
    127.0.0.1:3040: lines=153
    127.0.0.1:3020: lines=153
    127.0.0.1:3002: lines=232
    127.0.0.1:3030: lines=264
    127.0.0.1:3100: lines=201
    ```