### PR TITLE
[misc] hard code indexes on old find queries

### DIFF
--- a/app/js/MongoManager.js
+++ b/app/js/MongoManager.js
@@ -59,7 +59,9 @@ module.exports = MongoManager = {
     }
     db.docs
       .find(query, {
-        projection: filter
+        projection: filter,
+        // use a specific index
+        hint: 'project_id_1'
       })
       .toArray(callback)
   },
@@ -69,7 +71,11 @@ module.exports = MongoManager = {
       project_id: ObjectId(project_id.toString()),
       inS3: true
     }
-    db.docs.find(query).toArray(callback)
+    const options = {
+      // use a specific index
+      hint: 'project_id_1_inS3_1'
+    }
+    db.docs.find(query, options).toArray(callback)
   },
 
   getNonDeletedArchivedProjectDocs(project_id, callback) {
@@ -78,7 +84,11 @@ module.exports = MongoManager = {
       deleted: { $ne: true },
       inS3: true
     }
-    db.docs.find(query).toArray(callback)
+    const options = {
+      // use a specific index
+      hint: 'project_id_1_inS3_1'
+    }
+    db.docs.find(query, options).toArray(callback)
   },
 
   upsertIntoDocCollection(project_id, doc_id, updates, callback) {

--- a/test/acceptance/js/helpers/DocstoreApp.js
+++ b/test/acceptance/js/helpers/DocstoreApp.js
@@ -12,9 +12,17 @@
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
  */
 const app = require('../../../../app')
-const { waitForDb } = require('../../../../app/js/mongodb')
+const { db, waitForDb } = require('../../../../app/js/mongodb')
 require('logger-sharelatex').logger.level('error')
 const settings = require('settings-sharelatex')
+
+before(waitForDb)
+before('create indexes', async function () {
+  await db.docs.createIndexes([
+    { name: 'project_id_1', key: { project_id: 1 } },
+    { name: 'project_id_1_inS3_1', key: { project_id: 1, inS3: 1 } }
+  ])
+})
 
 module.exports = {
   running: false,

--- a/test/unit/js/MongoManagerTests.js
+++ b/test/unit/js/MongoManagerTests.js
@@ -127,7 +127,8 @@ describe('MongoManager', function () {
               deleted: { $ne: true }
             },
             {
-              projection: this.filter
+              projection: this.filter,
+              hint: 'project_id_1'
             }
           )
           .should.equal(true)
@@ -157,7 +158,8 @@ describe('MongoManager', function () {
               project_id: ObjectId(this.project_id)
             },
             {
-              projection: this.filter
+              projection: this.filter,
+              hint: 'project_id_1'
             }
           )
           .should.equal(true)


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/4211

I noticed that the new index would get used for basically every query with a project id now.

This PR is hard-coding the index usage to the old ones to avoid any performance surprises.

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/4211

### Review

Docs: 
> http://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#find
> `hint`  -- Tell the query to use specific indexes in the query. Object of indexes to use, `{'_id':1}`

#### Potential Impact

High. All read queries are affected.

#### Manual Testing Performed

- run acceptance tests
- run manual queries -- see https://github.com/overleaf/issues/issues/4211#issuecomment-815918693 and https://github.com/overleaf/web-internal/pull/3894#issue-611499485 (screenshots section)
