### PR TITLE
[MongoManager] drop name filter from getProjectsDeletedDocs

### DIFF
--- a/app/js/MongoManager.js
+++ b/app/js/MongoManager.js
@@ -39,9 +39,7 @@ module.exports = MongoManager = {
       .find(
         {
           project_id: ObjectId(project_id.toString()),
-          deleted: true,
-          // TODO(das7pad): remove name filter after back filling data
-          name: { $exists: true }
+          deleted: true
         },
         {
           projection: filter,

--- a/test/unit/js/MongoManagerTests.js
+++ b/test/unit/js/MongoManagerTests.js
@@ -192,8 +192,7 @@ describe('MongoManager', function () {
       this.db.docs.find
         .calledWith({
           project_id: ObjectId(this.project_id),
-          deleted: true,
-          name: { $exists: true }
+          deleted: true
         })
         .should.equal(true)
     })


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

For https://github.com/overleaf/issues/issues/3733
Depends on https://github.com/overleaf/web-internal/pull/3907
Chained onto https://github.com/overleaf/docstore/pull/99

This PR is dropping the `name` filter on deleted docs which safe-guards against incomplete responses while the deleted docs are not yet fully back-filled. After https://github.com/overleaf/web-internal/pull/3907 they will all have a `name`.

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/3733
Depends on https://github.com/overleaf/web-internal/pull/3907
Chained onto https://github.com/overleaf/docstore/pull/99

#### Potential Impact

Low.
