### PR TITLE
[DocArchiveManager] destroy in small batches

### DIFF
--- a/app/js/MongoManager.js
+++ b/app/js/MongoManager.js
@@ -57,11 +57,13 @@ module.exports = MongoManager = {
     if (!options.include_deleted) {
       query.deleted = { $ne: true }
     }
-    db.docs
-      .find(query, {
-        projection: filter
-      })
-      .toArray(callback)
+    const queryOptions = {
+      projection: filter
+    }
+    if (options.limit) {
+      queryOptions.limit = options.limit
+    }
+    db.docs.find(query, queryOptions).toArray(callback)
   },
 
   getArchivedProjectDocs(project_id, callback) {

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -40,7 +40,10 @@ const Settings = {
 
   max_deleted_docs: parseInt(process.env.MAX_DELETED_DOCS, 10) || 2000,
 
-  max_doc_length: parseInt(process.env.MAX_DOC_LENGTH) || 2 * 1024 * 1024 // 2mb
+  max_doc_length: parseInt(process.env.MAX_DOC_LENGTH) || 2 * 1024 * 1024, // 2mb
+
+  destroyBatchSize: parseInt(process.env.DESTROY_BATCH_SIZE, 10) || 2000,
+  parallelArchiveJobs: parseInt(process.env.PARALLEL_ARCHIVE_JOBS, 10) || 5
 }
 
 if (process.env.MONGO_CONNECTION_STRING != null) {

--- a/test/unit/js/DocArchiveManagerTests.js
+++ b/test/unit/js/DocArchiveManagerTests.js
@@ -518,6 +518,11 @@ describe('DocArchiveManager', function () {
   })
 
   describe('destroyAllDocs', function () {
+    beforeEach(function () {
+      MongoManager.promises.getProjectsDocs.onCall(0).resolves(mongoDocs)
+      MongoManager.promises.getProjectsDocs.onCall(1).resolves([])
+    })
+
     it('should resolve with valid arguments', async function () {
       await expect(DocArchiveManager.promises.destroyAllDocs(projectId)).to
         .eventually.be.fulfilled


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

For https://github.com/overleaf/issues/issues/3733
For https://digital-science.slack.com/archives/G6256GXGS/p1618503789429100?thread_ts=1618478997.407500&cid=G6256GXGS
We need to cleanup a very large number of docs for a project. Loading all the doc ids into memory OOM kills the pod. This PR is implementing a batched processing. 

This may help with cleaning up large projects in production too.

Bonus: All the parameter are configurable through settings now.

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/3733
For https://digital-science.slack.com/archives/G6256GXGS/p1618503789429100?thread_ts=1618478997.407500&cid=G6256GXGS

#### Potential Impact

Low.

#### Manual Testing Performed

- run tests
