### PR TITLE
[DocArchiveManager] retry the deletion of doc archives three times

### DIFF
--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -43,6 +43,7 @@ const Settings = {
   max_doc_length: parseInt(process.env.MAX_DOC_LENGTH) || 2 * 1024 * 1024, // 2mb
 
   destroyBatchSize: parseInt(process.env.DESTROY_BATCH_SIZE, 10) || 2000,
+  destroyRetryCount: parseInt(process.env.DESTROY_RETRY_COUNT || '3', 10),
   parallelArchiveJobs: parseInt(process.env.PARALLEL_ARCHIVE_JOBS, 10) || 5
 }
 


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/4252
For https://digital-science.slack.com/archives/G6256GXGS/p1620206798002500?thread_ts=1619600805.001300&cid=G6256GXGS

This PR is adding retries to the deletion of archives in GCS/S3/... There is config options for the retry count which defaults to 3, so one failure plus 3 more tries. Eventually it will throw the last error.

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/4252
For https://digital-science.slack.com/archives/G6256GXGS/p1620206798002500?thread_ts=1619600805.001300&cid=G6256GXGS

#### Potential Impact

Low.

#### Manual Testing Performed

- see added unit tests
