### PR TITLE
retrieve doc without unarchiving

### DIFF
--- a/app.js
+++ b/app.js
@@ -91,6 +91,8 @@ app.use(function (error, req, res, next) {
   logger.error({ err: error, req }, 'request errored')
   if (error instanceof Errors.NotFoundError) {
     return res.sendStatus(404)
+  } else if (error instanceof Errors.DocModifiedError) {
+    return res.sendStatus(409)
   } else {
     return res.status(500).send('Oops, something went wrong')
   }

--- a/app.js
+++ b/app.js
@@ -54,6 +54,7 @@ app.get('/project/:project_id/ranges', HttpController.getAllRanges)
 app.get('/project/:project_id/doc/:doc_id', HttpController.getDoc)
 app.get('/project/:project_id/doc/:doc_id/deleted', HttpController.isDocDeleted)
 app.get('/project/:project_id/doc/:doc_id/raw', HttpController.getRawDoc)
+app.get('/project/:project_id/doc/:doc_id/peek', HttpController.peekDoc)
 // Add 64kb overhead for the JSON encoding, and double the size to allow for ranges in the json payload
 app.post(
   '/project/:project_id/doc/:doc_id',

--- a/app/js/DocManager.js
+++ b/app/js/DocManager.js
@@ -172,7 +172,7 @@ module.exports = DocManager = {
       if (err) {
         return callback(err)
       }
-      MongoManager.WithRevCheck(
+      MongoManager.withRevCheck(
         doc,
         MongoManager.getDocVersion,
         function (error, version) {

--- a/app/js/Errors.js
+++ b/app/js/Errors.js
@@ -4,7 +4,10 @@ const { Errors } = require('@overleaf/object-persistor')
 
 class Md5MismatchError extends OError {}
 
+class DocModifiedError extends OError {}
+
 module.exports = {
   Md5MismatchError,
+  DocModifiedError,
   ...Errors,
 }

--- a/app/js/HttpController.js
+++ b/app/js/HttpController.js
@@ -55,6 +55,7 @@ module.exports = HttpController = {
       if (doc == null) {
         return res.sendStatus(404)
       } else {
+        res.setHeader('x-doc-status', doc.inS3 ? 'archived' : 'active')
         return res.json(HttpController._buildDocView(doc))
       }
     })

--- a/app/js/HttpController.js
+++ b/app/js/HttpController.js
@@ -44,6 +44,22 @@ module.exports = HttpController = {
     })
   },
 
+  peekDoc(req, res, next) {
+    const { project_id } = req.params
+    const { doc_id } = req.params
+    logger.log({ project_id, doc_id }, 'peeking doc')
+    DocManager.peekDoc(project_id, doc_id, function (error, doc) {
+      if (error) {
+        return next(error)
+      }
+      if (doc == null) {
+        return res.sendStatus(404)
+      } else {
+        return res.json(HttpController._buildDocView(doc))
+      }
+    })
+  },
+
   isDocDeleted(req, res, next) {
     const { doc_id: docId, project_id: projectId } = req.params
     DocManager.isDocDeleted(projectId, docId, function (error, deleted) {

--- a/app/js/MongoManager.js
+++ b/app/js/MongoManager.js
@@ -199,7 +199,7 @@ module.exports = MongoManager = {
   // Helper method  to support optimistic locking. Call the provided method for
   // an existing doc and return the result if the rev in mongo is unchanged when
   // checked afterwards. If the rev has changed, return a DocModifiedError.
-  WithRevCheck(doc, method, callback) {
+  withRevCheck(doc, method, callback) {
     method(doc._id, function (err, result) {
       if (err) return callback(err)
       MongoManager.getDocRev(doc._id, function (err, currentRev) {

--- a/app/js/MongoManager.js
+++ b/app/js/MongoManager.js
@@ -15,6 +15,7 @@ const { db, ObjectId } = require('./mongodb')
 const logger = require('logger-sharelatex')
 const metrics = require('@overleaf/metrics')
 const Settings = require('@overleaf/settings')
+const { DocModifiedError } = require('./Errors')
 const { promisify } = require('util')
 
 module.exports = MongoManager = {
@@ -176,6 +177,45 @@ module.exports = MongoManager = {
       },
       callback
     )
+  },
+
+  getDocRev(doc_id, callback) {
+    db.docs.findOne(
+      {
+        _id: ObjectId(doc_id.toString()),
+      },
+      {
+        projection: { rev: 1 },
+      },
+      function (err, doc) {
+        if (err != null) {
+          return callback(err)
+        }
+        callback(null, doc && doc.rev)
+      }
+    )
+  },
+
+  // Helper method  to support optimistic locking. Call the provided method for
+  // an existing doc and return the result if the rev in mongo is unchanged when
+  // checked afterwards. If the rev has changed, return a DocModifiedError.
+  WithRevCheck(doc, method, callback) {
+    method(doc._id, function (err, result) {
+      if (err) return callback(err)
+      MongoManager.getDocRev(doc._id, function (err, currentRev) {
+        if (err) return callback(err)
+        if (doc.rev !== currentRev) {
+          return callback(
+            new DocModifiedError('doc rev has changed', {
+              doc_id: doc._id,
+              rev: doc.rev,
+              currentRev,
+            })
+          )
+        }
+        return callback(null, result)
+      })
+    })
   },
 
   destroyDoc(doc_id, callback) {

--- a/app/js/MongoManager.js
+++ b/app/js/MongoManager.js
@@ -15,7 +15,7 @@ const { db, ObjectId } = require('./mongodb')
 const logger = require('logger-sharelatex')
 const metrics = require('@overleaf/metrics')
 const Settings = require('@overleaf/settings')
-const { DocModifiedError } = require('./Errors')
+const Errors = require('./Errors')
 const { promisify } = require('util')
 
 module.exports = MongoManager = {
@@ -206,7 +206,7 @@ module.exports = MongoManager = {
         if (err) return callback(err)
         if (doc.rev !== currentRev) {
           return callback(
-            new DocModifiedError('doc rev has changed', {
+            new Errors.DocModifiedError('doc rev has changed', {
               doc_id: doc._id,
               rev: doc.rev,
               currentRev,

--- a/test/acceptance/js/ArchiveDocsTests.js
+++ b/test/acceptance/js/ArchiveDocsTests.js
@@ -12,7 +12,7 @@
  * DS207: Consider shorter variations of null checks
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
  */
-process.env.BACKEND = 'gcs'
+
 const Settings = require('@overleaf/settings')
 const { expect } = require('chai')
 const { db, ObjectId } = require('../../../app/js/mongodb')

--- a/test/acceptance/js/GettingDocsFromArchiveTest.js
+++ b/test/acceptance/js/GettingDocsFromArchiveTest.js
@@ -113,40 +113,41 @@ describe('Getting A Doc from Archive', function () {
       )
     })
 
-  describe('for an non-archived doc', function () {
-    before(function (done) {
-      this.project_id = ObjectId()
-      this.timeout(1000 * 30)
-      this.doc = {
-        _id: ObjectId(),
-        lines: ['foo', 'bar'],
-        ranges: {},
-        version: 2,
-      }
-      DocstoreClient.createDoc(
-        this.project_id,
-        this.doc._id,
-        this.doc.lines,
-        this.doc.version,
-        this.doc.ranges,
-        done
-      )
-    })
-
-    it('should return the doc lines and version from mongo', function (done) {
-      return DocstoreClient.peekDoc(
-        this.project_id,
-        this.doc._id,
-        {},
-        (error, res, doc) => {
-          res.statusCode.should.equal(200)
-          res.headers['x-doc-status'].should.equal('active')
-          doc.lines.should.deep.equal(this.doc.lines)
-          doc.version.should.equal(this.doc.version)
-          doc.ranges.should.deep.equal(this.doc.ranges)
-          return done()
+    describe('for an non-archived doc', function () {
+      before(function (done) {
+        this.project_id = ObjectId()
+        this.timeout(1000 * 30)
+        this.doc = {
+          _id: ObjectId(),
+          lines: ['foo', 'bar'],
+          ranges: {},
+          version: 2,
         }
-      )
+        DocstoreClient.createDoc(
+          this.project_id,
+          this.doc._id,
+          this.doc.lines,
+          this.doc.version,
+          this.doc.ranges,
+          done
+        )
+      })
+
+      it('should return the doc lines and version from mongo', function (done) {
+        return DocstoreClient.peekDoc(
+          this.project_id,
+          this.doc._id,
+          {},
+          (error, res, doc) => {
+            res.statusCode.should.equal(200)
+            res.headers['x-doc-status'].should.equal('active')
+            doc.lines.should.deep.equal(this.doc.lines)
+            doc.version.should.equal(this.doc.version)
+            doc.ranges.should.deep.equal(this.doc.ranges)
+            return done()
+          }
+        )
+      })
     })
   })
 })

--- a/test/acceptance/js/GettingDocsFromArchiveTest.js
+++ b/test/acceptance/js/GettingDocsFromArchiveTest.js
@@ -1,0 +1,99 @@
+/* eslint-disable
+    camelcase,
+    handle-callback-err,
+    no-unused-vars,
+*/
+// TODO: This file was created by bulk-decaffeinate.
+// Fix any style issues and re-enable lint.
+/*
+ * decaffeinate suggestions:
+ * DS101: Remove unnecessary use of Array.from
+ * DS102: Remove unnecessary code created because of implicit returns
+ * DS207: Consider shorter variations of null checks
+ * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
+ */
+process.env.BACKEND = 'gcs'
+const Settings = require('@overleaf/settings')
+const { expect } = require('chai')
+const { db, ObjectId } = require('../../../app/js/mongodb')
+const async = require('async')
+const DocstoreApp = require('./helpers/DocstoreApp')
+const DocstoreClient = require('./helpers/DocstoreClient')
+const { Storage } = require('@google-cloud/storage')
+const Persistor = require('../../../app/js/PersistorManager')
+const Streamifier = require('streamifier')
+
+function uploadContent(path, json, callback) {
+  const stream = Streamifier.createReadStream(JSON.stringify(json))
+  Persistor.sendStream(Settings.docstore.bucket, path, stream)
+    .then(() => callback())
+    .catch(callback)
+}
+
+describe('Getting A Doc from Archive', function () {
+  before(function (done) {
+    return DocstoreApp.ensureRunning(done)
+  })
+
+  before(async function () {
+    const storage = new Storage(Settings.docstore.gcs.endpoint)
+    await storage.createBucket(Settings.docstore.bucket)
+    await storage.createBucket(`${Settings.docstore.bucket}-deleted`)
+  })
+
+  describe('archiving a single doc', function () {
+    before(function (done) {
+      this.project_id = ObjectId()
+      this.timeout(1000 * 30)
+      this.doc = {
+        _id: ObjectId(),
+        lines: ['foo', 'bar'],
+        ranges: {},
+        version: 2,
+      }
+      DocstoreClient.createDoc(
+        this.project_id,
+        this.doc._id,
+        this.doc.lines,
+        this.doc.version,
+        this.doc.ranges,
+        error => {
+          if (error) {
+            return done(error)
+          }
+          DocstoreClient.archiveDocById(
+            this.project_id,
+            this.doc._id,
+            (error, res) => {
+              this.res = res
+              if (error) {
+                return done(error)
+              }
+              done()
+            }
+          )
+        }
+      )
+    })
+
+    it('should successully archive the doc', function (done) {
+      this.res.statusCode.should.equal(204)
+      done()
+    })
+
+    it('should get the doc lines and version', function (done) {
+      return DocstoreClient.peekDoc(
+        this.project_id,
+        this.doc._id,
+        {},
+        (error, res, doc) => {
+          res.statusCode.should.equal(200)
+          doc.lines.should.deep.equal(this.doc.lines)
+          doc.version.should.equal(this.doc.version)
+          doc.ranges.should.deep.equal(this.doc.ranges)
+          return done()
+        }
+      )
+    })
+  })
+})

--- a/test/acceptance/js/GettingDocsFromArchiveTest.js
+++ b/test/acceptance/js/GettingDocsFromArchiveTest.js
@@ -1,34 +1,8 @@
-/* eslint-disable
-    camelcase,
-    handle-callback-err,
-    no-unused-vars,
-*/
-// TODO: This file was created by bulk-decaffeinate.
-// Fix any style issues and re-enable lint.
-/*
- * decaffeinate suggestions:
- * DS101: Remove unnecessary use of Array.from
- * DS102: Remove unnecessary code created because of implicit returns
- * DS207: Consider shorter variations of null checks
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
-process.env.BACKEND = 'gcs'
 const Settings = require('@overleaf/settings')
-const { expect } = require('chai')
-const { db, ObjectId } = require('../../../app/js/mongodb')
-const async = require('async')
+const { ObjectId } = require('../../../app/js/mongodb')
 const DocstoreApp = require('./helpers/DocstoreApp')
 const DocstoreClient = require('./helpers/DocstoreClient')
 const { Storage } = require('@google-cloud/storage')
-const Persistor = require('../../../app/js/PersistorManager')
-const Streamifier = require('streamifier')
-
-function uploadContent(path, json, callback) {
-  const stream = Streamifier.createReadStream(JSON.stringify(json))
-  Persistor.sendStream(Settings.docstore.bucket, path, stream)
-    .then(() => callback())
-    .catch(callback)
-}
 
 describe('Getting A Doc from Archive', function () {
   before(function (done) {

--- a/test/acceptance/js/helpers/DocstoreClient.js
+++ b/test/acceptance/js/helpers/DocstoreClient.js
@@ -61,10 +61,7 @@ module.exports = DocstoreClient = {
   },
 
   peekDoc(project_id, doc_id, qs, callback) {
-    if (callback == null) {
-      callback = function (error, res, body) {}
-    }
-    return request.get(
+    request.get(
       {
         url: `http://localhost:${settings.internal.docstore.port}/project/${project_id}/doc/${doc_id}/peek`,
         json: true,

--- a/test/acceptance/js/helpers/DocstoreClient.js
+++ b/test/acceptance/js/helpers/DocstoreClient.js
@@ -60,6 +60,20 @@ module.exports = DocstoreClient = {
     )
   },
 
+  peekDoc(project_id, doc_id, qs, callback) {
+    if (callback == null) {
+      callback = function (error, res, body) {}
+    }
+    return request.get(
+      {
+        url: `http://localhost:${settings.internal.docstore.port}/project/${project_id}/doc/${doc_id}/peek`,
+        json: true,
+        qs,
+      },
+      callback
+    )
+  },
+
   isDocDeleted(project_id, doc_id, callback) {
     request.get(
       {

--- a/test/setup.js
+++ b/test/setup.js
@@ -4,6 +4,8 @@ const sinonChai = require('sinon-chai')
 const chaiAsPromised = require('chai-as-promised')
 const SandboxedModule = require('sandboxed-module')
 
+process.env.BACKEND = 'gcs'
+
 // Chai configuration
 chai.should()
 chai.use(sinonChai)

--- a/test/unit/js/MongoManagerTests.js
+++ b/test/unit/js/MongoManagerTests.js
@@ -29,7 +29,7 @@ describe('MongoManager', function () {
         },
         '@overleaf/metrics': { timeAsyncMethod: sinon.stub() },
         '@overleaf/settings': { max_deleted_docs: 42 },
-        './Errors': { Errors },
+        './Errors': Errors,
       },
     })
     this.project_id = ObjectId().toString()
@@ -307,7 +307,7 @@ describe('MongoManager', function () {
     })
   })
 
-  return describe('setDocVersion', function () {
+  describe('setDocVersion', function () {
     beforeEach(function () {
       this.version = 42
       this.db.docOps.updateOne = sinon.stub().callsArg(3)
@@ -338,6 +338,38 @@ describe('MongoManager', function () {
 
     return it('should call the callback', function () {
       return this.callback.called.should.equal(true)
+    })
+  })
+
+  describe('withRevCheck', function () {
+    this.beforeEach(function () {
+      this.doc = { _id: ObjectId(), name: 'mock-doc', rev: 1 }
+      this.testFunction = sinon.stub().yields(null, 'foo')
+    })
+
+    it('should call the callback when the rev has not changed', function (done) {
+      this.db.docs.findOne = sinon.stub().callsArgWith(2, null, { rev: 1 })
+      this.MongoManager.withRevCheck(
+        this.doc,
+        this.testFunction,
+        (err, result) => {
+          result.should.equal('foo')
+          assert.isNull(err)
+          done()
+        }
+      )
+    })
+
+    it('should return an error when the rev has changed', function (done) {
+      this.db.docs.findOne = sinon.stub().callsArgWith(2, null, { rev: 2 })
+      this.MongoManager.withRevCheck(
+        this.doc,
+        this.testFunction,
+        (err, result) => {
+          err.should.be.instanceof(Errors.DocModifiedError)
+          done()
+        }
+      )
     })
   })
 })

--- a/test/unit/js/MongoManagerTests.js
+++ b/test/unit/js/MongoManagerTests.js
@@ -17,6 +17,7 @@ const modulePath = require('path').join(
 )
 const { ObjectId } = require('mongodb')
 const { assert } = require('chai')
+const Errors = require('../../../app/js/Errors')
 
 describe('MongoManager', function () {
   beforeEach(function () {
@@ -28,6 +29,7 @@ describe('MongoManager', function () {
         },
         '@overleaf/metrics': { timeAsyncMethod: sinon.stub() },
         '@overleaf/settings': { max_deleted_docs: 42 },
+        './Errors': { Errors },
       },
     })
     this.project_id = ObjectId().toString()


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

This PR adds a `peek` method to retrieve a doc from mongo or persistent storage without unarchiving it.

#### Screenshots

N/A

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/4539

Used by https://github.com/overleaf/track-changes/pull/117

### Review

I've tried to minimise changes to the existing code paths.

The one change I did make was to refactor `DocArchiveManager` to split the `unarchiveDoc` method into `getDoc` and `unarchiveDoc` methods, so that we can use the same code to fetch the doc without unarchiving it.

The changes for that are in the first commit "refactor unarchiveDoc to use a separate getDoc helper".

The second commit adds the `peek` methods.

I've also added a `withRevCheck` method to allow for optimistic locking.  Currently we don't have reliable locking in docstore when projects move between mongo and archiving.   We have checks in various places that catch the case where two things happen at once.   The `withRevCheck` method formalises this - if you give it the starting document and a method (which should be a read-only method), it will call that method with the doc._id but only return the result if the `rev` field hasn't changed from the original value. 

We want to get the `version` field from the doc in mongo, and the doc content from GCS, so we call `MongoManager.withRevCheck(doc, MongoManager.getDocversion, callback)` and get a callback of `callback(null,version)` if the rev value hasn't been modified.  Otherwise we get a callback with a `DocModified` error. 

For acceptance testing I've added an `x-doc-status` header on the `peek` response, with values of `active` or `archived` depending on where the doc was retrieved from.

#### Potential Impact

Doc retrieval 

#### Manual Testing Performed

- [x]  Unit and acceptance tests 
- [x] Test in local dev env

```sh
$ curl -v localhost:3016/project/60f6a7329ccb0e0026fd1357/doc/60f6a7339ccb0e0026fd1359/peek
< HTTP/1.1 200 OK
< X-Powered-By: Express
< x-doc-status: active
< Content-Type: application/json; charset=utf-8
< Content-Length: 1141

{"_id":"60f6a7339ccb0e0026fd1359","lines":["\\documentclass{article}",....,"\\end{document}",""],"rev":16,"version":81,"ranges":{}}

$ curl -X POST -v localhost:3016/project/60f6a7329ccb0e0026fd1357/doc/60f6a7339ccb0e0026fd1359/archive
< HTTP/1.1 204 No Content

$ curl -v localhost:3016/project/60f6a7329ccb0e0026fd1357/doc/60f6a7339ccb0e0026fd1359/peek
< HTTP/1.1 200 OK
< X-Powered-By: Express
< x-doc-status: archived
< Content-Type: application/json; charset=utf-8
< Content-Length: 1141

{"_id":"60f6a7339ccb0e0026fd1359","lines":["\\documentclass{article}",....,"\\end{document}",""],"rev":16,"version":81,"ranges":{}}
```

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

NA

#### Who Needs to Know?

cc @aeaton-overleaf @thomas- 