### PR TITLE
Rename misnamed "filter" variable to "projection"

### DIFF
--- a/app/js/DocManager.js
+++ b/app/js/DocManager.js
@@ -205,11 +205,11 @@ module.exports = DocManager = {
     )
   },
 
-  getAllDeletedDocs(project_id, filter, callback) {
-    MongoManager.getProjectsDeletedDocs(project_id, filter, callback)
+  getAllDeletedDocs(project_id, projection, callback) {
+    MongoManager.getProjectsDeletedDocs(project_id, projection, callback)
   },
 
-  getAllNonDeletedDocs(project_id, filter, callback) {
+  getAllNonDeletedDocs(project_id, projection, callback) {
     if (callback == null) {
       callback = function (error, docs) {}
     }
@@ -220,7 +220,7 @@ module.exports = DocManager = {
       return MongoManager.getProjectsDocs(
         project_id,
         { include_deleted: false },
-        filter,
+        projection,
         function (error, docs) {
           if (typeof err !== 'undefined' && err !== null) {
             return callback(error)

--- a/app/js/MongoManager.js
+++ b/app/js/MongoManager.js
@@ -19,7 +19,7 @@ const Errors = require('./Errors')
 const { promisify } = require('util')
 
 module.exports = MongoManager = {
-  findDoc(project_id, doc_id, filter, callback) {
+  findDoc(project_id, doc_id, projection, callback) {
     if (callback == null) {
       callback = function (error, doc) {}
     }
@@ -29,13 +29,13 @@ module.exports = MongoManager = {
         project_id: ObjectId(project_id.toString()),
       },
       {
-        projection: filter,
+        projection
       },
       callback
     )
   },
 
-  getProjectsDeletedDocs(project_id, filter, callback) {
+  getProjectsDeletedDocs(project_id, projection, callback) {
     db.docs
       .find(
         {
@@ -43,7 +43,7 @@ module.exports = MongoManager = {
           deleted: true,
         },
         {
-          projection: filter,
+          projection,
           sort: { deletedAt: -1 },
           limit: Settings.max_deleted_docs,
         }
@@ -51,13 +51,13 @@ module.exports = MongoManager = {
       .toArray(callback)
   },
 
-  getProjectsDocs(project_id, options, filter, callback) {
+  getProjectsDocs(project_id, options, projection, callback) {
     const query = { project_id: ObjectId(project_id.toString()) }
     if (!options.include_deleted) {
       query.deleted = { $ne: true }
     }
     const queryOptions = {
-      projection: filter,
+      projection
     }
     if (options.limit) {
       queryOptions.limit = options.limit

--- a/test/unit/js/DocManagerTests.js
+++ b/test/unit/js/DocManagerTests.js
@@ -325,17 +325,17 @@ describe('DocManager', function () {
         this.DocArchiveManager.unArchiveAllDocs = sinon
           .stub()
           .callsArgWith(1, null, this.docs)
-        this.filter = { lines: true }
+        this.projection = { lines: true }
         return this.DocManager.getAllNonDeletedDocs(
           this.project_id,
-          this.filter,
+          this.projection,
           this.callback
         )
       })
 
       it('should get the project from the database', function () {
         return this.MongoManager.getProjectsDocs
-          .calledWith(this.project_id, { include_deleted: false }, this.filter)
+          .calledWith(this.project_id, { include_deleted: false }, this.projection)
           .should.equal(true)
       })
 
@@ -354,7 +354,7 @@ describe('DocManager', function () {
           .callsArgWith(1, null)
         return this.DocManager.getAllNonDeletedDocs(
           this.project_id,
-          this.filter,
+          this.projection,
           this.callback
         )
       })

--- a/test/unit/js/MongoManagerTests.js
+++ b/test/unit/js/MongoManagerTests.js
@@ -42,11 +42,11 @@ describe('MongoManager', function () {
     beforeEach(function () {
       this.doc = { name: 'mock-doc' }
       this.db.docs.findOne = sinon.stub().callsArgWith(2, null, this.doc)
-      this.filter = { lines: true }
+      this.projection = { lines: true }
       return this.MongoManager.findDoc(
         this.project_id,
         this.doc_id,
-        this.filter,
+        this.projection,
         this.callback
       )
     })
@@ -59,7 +59,7 @@ describe('MongoManager', function () {
             project_id: ObjectId(this.project_id),
           },
           {
-            projection: this.filter,
+            projection: this.projection,
           }
         )
         .should.equal(true)
@@ -99,7 +99,7 @@ describe('MongoManager', function () {
 
   describe('getProjectsDocs', function () {
     beforeEach(function () {
-      this.filter = { lines: true }
+      this.projection = { lines: true }
       this.doc1 = { name: 'mock-doc1' }
       this.doc2 = { name: 'mock-doc2' }
       this.doc3 = { name: 'mock-doc3' }
@@ -116,7 +116,7 @@ describe('MongoManager', function () {
         return this.MongoManager.getProjectsDocs(
           this.project_id,
           { include_deleted: false },
-          this.filter,
+          this.projection,
           this.callback
         )
       })
@@ -129,7 +129,7 @@ describe('MongoManager', function () {
               deleted: { $ne: true },
             },
             {
-              projection: this.filter,
+              projection: this.projection,
             }
           )
           .should.equal(true)
@@ -147,7 +147,7 @@ describe('MongoManager', function () {
         return this.MongoManager.getProjectsDocs(
           this.project_id,
           { include_deleted: true },
-          this.filter,
+          this.projection,
           this.callback
         )
       })
@@ -159,7 +159,7 @@ describe('MongoManager', function () {
               project_id: ObjectId(this.project_id),
             },
             {
-              projection: this.filter,
+              projection: this.projection,
             }
           )
           .should.equal(true)
@@ -175,7 +175,7 @@ describe('MongoManager', function () {
 
   describe('getProjectsDeletedDocs', function () {
     beforeEach(function (done) {
-      this.filter = { name: true }
+      this.projection = { name: true }
       this.doc1 = { _id: '1', name: 'mock-doc1.tex' }
       this.doc2 = { _id: '2', name: 'mock-doc2.tex' }
       this.doc3 = { _id: '3', name: 'mock-doc3.tex' }
@@ -185,7 +185,7 @@ describe('MongoManager', function () {
       this.callback.callsFake(done)
       this.MongoManager.getProjectsDeletedDocs(
         this.project_id,
-        this.filter,
+        this.projection,
         this.callback
       )
     })
@@ -202,7 +202,7 @@ describe('MongoManager', function () {
     it('should filter, sort by deletedAt and limit', function () {
       this.db.docs.find
         .calledWith(sinon.match.any, {
-          projection: this.filter,
+          projection: this.projection,
           sort: { deletedAt: -1 },
           limit: 42,
         })


### PR DESCRIPTION
There were several places where a variable passed to a MongoDB query as `projection` was confusingly named `filter`.